### PR TITLE
Changes default file name from `docker-compose.yml` to `compose.yaml`

### DIFF
--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -122,7 +122,7 @@ func newComposeRenderCmd() *cobra.Command {
 					title = title + " (+" + strconv.Itoa(len(app.Files)-1) + ")"
 				}
 			} else {
-				title = "docker-compose.yml"
+				title = "compose.yaml"
 			}
 
 			return ui.RenderYAMLInPagerTTY(cmd.InOrStdin(), cmd.OutOrStdout(), raw, title)

--- a/internal/manifest/validation.go
+++ b/internal/manifest/validation.go
@@ -8,18 +8,19 @@ import (
 	"github.com/gcstr/dockform/internal/apperr"
 )
 
-// findDefaultComposeFile looks for docker-compose files with .yaml or .yml extensions
-// in the given directory, preferring .yaml over .yml if both exist.
+// findDefaultComposeFile looks for compose files in the given directory, selecting in order:
+// compose.yaml > compose.yml > docker-compose.yaml > docker-compose.yml. If none exist,
+// it defaults to compose.yaml under the provided directory.
 func findDefaultComposeFile(dir string) string {
-	candidates := []string{"docker-compose.yaml", "docker-compose.yml"}
+	candidates := []string{"compose.yaml", "compose.yml", "docker-compose.yaml", "docker-compose.yml"}
 	for _, candidate := range candidates {
 		fullPath := filepath.Join(dir, candidate)
 		if _, err := os.Stat(fullPath); err == nil {
 			return fullPath
 		}
 	}
-	// If neither exists, default to .yml for consistency with existing behavior
-	return filepath.Join(dir, "docker-compose.yml")
+	// If none exist, default to compose.yaml for modern Compose behavior
+	return filepath.Join(dir, "compose.yaml")
 }
 
 func (c *Config) normalizeAndValidate(baseDir string) error {


### PR DESCRIPTION
Update the default compose file names according to Docker documentation: https://docs.docker.com/compose/intro/compose-application-model/#the-compose-file

Closes #2 