### PR TITLE
Adds PGP backend support for SOPS secrets

### DIFF
--- a/examples/overview/README.md
+++ b/examples/overview/README.md
@@ -8,8 +8,8 @@ docker:
 sops:
   age:
     key_file: ${AGE_KEY_FILE}
-  recipients: 
-    - age1vmn3nv333mprv02cn8qyafxaz94zg368lnk5gsclmme9ryludysswn5rgr
+    recipients: 
+      - age1vmn3nv333mprv02cn8qyafxaz94zg368lnk5gsclmme9ryludysswn5rgr
 
 secrets:
   sops:

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -67,8 +67,10 @@ func newDoctorCmd() *cobra.Command {
 			// [compose]
 			results = append(results, checkCompose(ctx, docker))
 
-			// [sops]
-			results = append(results, checkSops())
+            // [sops]
+            results = append(results, checkSops())
+            // [gpg]
+            results = append(results, checkGpg())
 
 			// [helper]
 			results = append(results, checkHelperImage(ctx, docker))
@@ -241,6 +243,42 @@ func checkSops() checkResult {
 		return checkResult{id: "sops", title: "SOPS present", status: statusPass, summary: "installed", sub: sub}
 	}
 	return checkResult{id: "sops", title: "SOPS present", status: statusPass, summary: ver, sub: sub}
+}
+
+func checkGpg() checkResult {
+    if _, err := exec.LookPath("gpg"); err != nil {
+        // Not fatal; only warn if gpg not present
+        return checkResult{id: "gpg", title: "GnuPG", status: statusWarn, summary: "gpg not found", note: "Tip: Install GnuPG if using PGP with SOPS."}
+    }
+    // Version and loopback support
+    out, _ := exec.Command("gpg", "--version").CombinedOutput()
+    lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
+    var ver string
+    if len(lines) > 0 {
+        ver = strings.TrimSpace(lines[0])
+    }
+    sub := []string{}
+    // Agent socket dir (best effort)
+    if _, err := exec.LookPath("gpgconf"); err == nil {
+        if b, err := exec.Command("gpgconf", "--list-dirs", "agent-socket").CombinedOutput(); err == nil {
+            socket := strings.TrimSpace(string(b))
+            if socket != "" {
+                sub = append(sub, "agent socket: "+socket)
+            }
+        }
+    }
+    // Check loopback support by looking for pinentry-mode mention in help
+    helpOut, _ := exec.Command("gpg", "--help").CombinedOutput()
+    loopbackSupported := strings.Contains(string(helpOut), "pinentry-mode")
+    if loopbackSupported {
+        sub = append(sub, "loopback: supported")
+    } else {
+        sub = append(sub, "loopback: unknown (try gpg>=2.1)")
+    }
+    if ver == "" {
+        ver = "installed"
+    }
+    return checkResult{id: "gpg", title: "GnuPG present", status: statusPass, summary: ver, sub: sub}
 }
 
 func checkHelperImage(ctx context.Context, docker *dockercli.Client) checkResult {

--- a/internal/cli/doctor_scenarios_test.go
+++ b/internal/cli/doctor_scenarios_test.go
@@ -32,8 +32,8 @@ func TestDoctorCmd_AllHealthy(t *testing.T) {
 		t.Errorf("missing context info, got: %q", output)
 	}
 
-	// Check all 7 checks are present
-	requiredChecks := []string{"[engine]", "[context]", "[compose]", "[sops]", "[helper]", "[net-perms]", "[vol-perms]"}
+	// Check all expected checks are present
+	requiredChecks := []string{"[engine]", "[context]", "[compose]", "[sops]", "[gpg]", "[helper]", "[net-perms]", "[vol-perms]"}
 	for _, check := range requiredChecks {
 		if !strings.Contains(output, check) {
 			t.Errorf("missing check %q in output: %q", check, output)
@@ -41,10 +41,10 @@ func TestDoctorCmd_AllHealthy(t *testing.T) {
 	}
 
 	// Check summary
-	if !strings.Contains(output, "Summary: 7 checks") {
+	if !strings.Contains(output, "Summary: 8 checks") {
 		t.Errorf("missing summary line, got: %q", output)
 	}
-	if !strings.Contains(output, "7 PASS, 0 WARN, 0 FAIL") {
+	if !strings.Contains(output, "8 PASS, 0 WARN, 0 FAIL") {
 		t.Errorf("expected all pass, got: %q", output)
 	}
 	if !strings.Contains(output, "All good!") {

--- a/internal/cli/secret.go
+++ b/internal/cli/secret.go
@@ -28,19 +28,46 @@ func newSecretCmd() *cobra.Command {
 	return cmd
 }
 
-func resolveRecipientsAndKey(cfg manifest.Config) ([]string, string, error) {
-	if cfg.Sops == nil || cfg.Sops.Age == nil || cfg.Sops.Age.KeyFile == "" {
-		return nil, "", apperr.New("cli.resolveRecipientsAndKey", apperr.InvalidInput, "sops age key_file not configured")
-	}
-	recipients := cfg.Sops.Recipients
-	if len(recipients) == 0 {
-		r, err := secrets.AgeRecipientsFromKeyFile(cfg.Sops.Age.KeyFile)
-		if err != nil {
-			return nil, "", err
-		}
-		recipients = r
-	}
-	return recipients, cfg.Sops.Age.KeyFile, nil
+type sopsResolved struct {
+    opts          secrets.SopsOptions
+    ageRecipients []string
+}
+
+func resolveRecipientsAndKey(cfg manifest.Config) (sopsResolved, error) {
+    if cfg.Sops == nil {
+        return sopsResolved{}, apperr.New("cli.resolveRecipientsAndKey", apperr.InvalidInput, "sops config not configured")
+    }
+    var ageRecipients []string
+    ageKey := ""
+    if cfg.Sops.Age != nil {
+        ageKey = cfg.Sops.Age.KeyFile
+        // Prefer explicit recipients, else derive from key file
+        if len(cfg.Sops.Age.Recipients) > 0 {
+            ageRecipients = cfg.Sops.Age.Recipients
+        } else if strings.TrimSpace(ageKey) != "" {
+            r, err := secrets.AgeRecipientsFromKeyFile(ageKey)
+            if err != nil {
+                return sopsResolved{}, err
+            }
+            ageRecipients = r
+        }
+    }
+    var pgpRecipients []string
+    pgpDir := ""
+    pgpAgent := false
+    pgpMode := ""
+    pgpPass := ""
+    if cfg.Sops.Pgp != nil {
+        pgpRecipients = cfg.Sops.Pgp.Recipients
+        pgpDir = cfg.Sops.Pgp.KeyringDir
+        pgpAgent = cfg.Sops.Pgp.UseAgent
+        pgpMode = cfg.Sops.Pgp.PinentryMode
+        pgpPass = cfg.Sops.Pgp.Passphrase
+    }
+    if len(ageRecipients) == 0 && len(pgpRecipients) == 0 {
+        return sopsResolved{}, apperr.New("cli.resolveRecipientsAndKey", apperr.InvalidInput, "no sops recipients configured (age or pgp)")
+    }
+    return sopsResolved{opts: secrets.SopsOptions{AgeKeyFile: ageKey, AgeRecipients: ageRecipients, PgpKeyringDir: pgpDir, PgpUseAgent: pgpAgent, PgpPinentryMode: pgpMode, PgpPassphrase: pgpPass, PgpRecipients: pgpRecipients}, ageRecipients: ageRecipients}, nil
 }
 
 func newSecretCreateCmd() *cobra.Command {
@@ -63,7 +90,7 @@ func newSecretCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			recipients, keyFile, err := resolveRecipientsAndKey(cfg)
+            resolved, err := resolveRecipientsAndKey(cfg)
 			if err != nil {
 				return err
 			}
@@ -78,7 +105,7 @@ func newSecretCreateCmd() *cobra.Command {
 			if err := os.WriteFile(path, []byte("SECRET_KEY=secret\n"), 0o600); err != nil {
 				return err
 			}
-			if err := secrets.EncryptDotenvFileWithSops(context.Background(), path, recipients, keyFile); err != nil {
+            if err := secrets.EncryptDotenvFileWithSops(context.Background(), path, resolved.opts.AgeRecipients, resolved.opts.AgeKeyFile, resolved.opts.PgpRecipients, resolved.opts.PgpKeyringDir, resolved.opts.PgpUseAgent, resolved.opts.PgpPinentryMode, resolved.opts.PgpPassphrase); err != nil {
 				return err
 			}
 			if _, err := fmt.Fprintln(cmd.OutOrStdout(), "secret created:", path); err != nil {
@@ -110,7 +137,7 @@ func newSecretRekeyCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			recipients, keyFile, err := resolveRecipientsAndKey(cfg)
+            resolved, err := resolveRecipientsAndKey(cfg)
 			if err != nil {
 				return err
 			}
@@ -122,7 +149,7 @@ func newSecretRekeyCmd() *cobra.Command {
 				if !filepath.IsAbs(path) {
 					path = filepath.Join(cfg.BaseDir, path)
 				}
-				pairs, err := secrets.DecryptAndParse(cmd.Context(), path, keyFile)
+                pairs, err := secrets.DecryptAndParse(cmd.Context(), path, resolved.opts)
 				if err != nil {
 					return err
 				}
@@ -130,7 +157,7 @@ func newSecretRekeyCmd() *cobra.Command {
 				if err := os.WriteFile(path, []byte(plain), 0o600); err != nil {
 					return err
 				}
-				if err := secrets.EncryptDotenvFileWithSops(cmd.Context(), path, recipients, keyFile); err != nil {
+                if err := secrets.EncryptDotenvFileWithSops(cmd.Context(), path, resolved.opts.AgeRecipients, resolved.opts.AgeKeyFile, resolved.opts.PgpRecipients, resolved.opts.PgpKeyringDir, resolved.opts.PgpUseAgent, resolved.opts.PgpPinentryMode, resolved.opts.PgpPassphrase); err != nil {
 					return err
 				}
 				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s reencrypted\n", p); err != nil {
@@ -163,7 +190,19 @@ func newSecretDecryptCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			pairs, err := secrets.DecryptAndParse(cmd.Context(), args[0], cfg.Sops.Age.KeyFile)
+            var opts secrets.SopsOptions
+            if cfg.Sops != nil {
+                if cfg.Sops.Age != nil {
+                    opts.AgeKeyFile = cfg.Sops.Age.KeyFile
+                }
+                if cfg.Sops.Pgp != nil {
+                    opts.PgpKeyringDir = cfg.Sops.Pgp.KeyringDir
+                    opts.PgpUseAgent = cfg.Sops.Pgp.UseAgent
+                    opts.PgpPinentryMode = cfg.Sops.Pgp.PinentryMode
+                    opts.PgpPassphrase = cfg.Sops.Pgp.Passphrase
+                }
+            }
+            pairs, err := secrets.DecryptAndParse(cmd.Context(), args[0], opts)
 			if err != nil {
 				return err
 			}
@@ -197,7 +236,7 @@ func newSecretEditCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			recipients, keyFile, err := resolveRecipientsAndKey(cfg)
+            resolved, err := resolveRecipientsAndKey(cfg)
 			if err != nil {
 				return err
 			}
@@ -207,7 +246,7 @@ func newSecretEditCmd() *cobra.Command {
 				return err
 			}
 			defer func() { _ = os.Remove(tmp.Name()) }()
-			pairs, err := secrets.DecryptAndParse(cmd.Context(), path, keyFile)
+            pairs, err := secrets.DecryptAndParse(cmd.Context(), path, resolved.opts)
 			if err != nil {
 				return err
 			}
@@ -234,7 +273,7 @@ func newSecretEditCmd() *cobra.Command {
 			if err := os.WriteFile(path, b, 0o600); err != nil {
 				return err
 			}
-			if err := secrets.EncryptDotenvFileWithSops(cmd.Context(), path, recipients, keyFile); err != nil {
+            if err := secrets.EncryptDotenvFileWithSops(cmd.Context(), path, resolved.opts.AgeRecipients, resolved.opts.AgeKeyFile, resolved.opts.PgpRecipients, resolved.opts.PgpKeyringDir, resolved.opts.PgpUseAgent, resolved.opts.PgpPinentryMode, resolved.opts.PgpPassphrase); err != nil {
 				return err
 			}
 			if _, err := fmt.Fprintln(cmd.OutOrStdout(), "secret updated:", path); err != nil {

--- a/internal/cli/secret_test.go
+++ b/internal/cli/secret_test.go
@@ -126,7 +126,7 @@ func TestSecret_Rekey_Success(t *testing.T) {
 	t.Setenv("SOPS_AGE_KEY_FILE", keyPath)
 	// First, create an encrypted secret using create
 	cfgCreatePath := filepath.Join(dir, "create.yml")
-	cfgCreate := "docker:\n  identifier: test-id\nsops:\n  age:\n    key_file: " + keyPath + "\n  recipients:\n    - " + recipient + "\n"
+	cfgCreate := "docker:\n  identifier: test-id\nsops:\n  age:\n    key_file: " + keyPath + "\n    recipients:\n      - " + recipient + "\n"
 	if err := os.WriteFile(cfgCreatePath, []byte(cfgCreate), 0o644); err != nil {
 		t.Fatalf("write create config: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestSecret_Rekey_Success(t *testing.T) {
 
 	// Now, run rekey pointing to the created secret path via config
 	cfgRekeyPath := filepath.Join(dir, "rekey.yml")
-	cfgRekey := "docker:\n  identifier: test-id\nsops:\n  age:\n    key_file: " + keyPath + "\n  recipients:\n    - " + recipient + "\nsecrets:\n  sops:\n    - secrets.env\n"
+	cfgRekey := "docker:\n  identifier: test-id\nsops:\n  age:\n    key_file: " + keyPath + "\n    recipients:\n      - " + recipient + "\nsecrets:\n  sops:\n    - secrets.env\n"
 	if err := os.WriteFile(cfgRekeyPath, []byte(cfgRekey), 0o644); err != nil {
 		t.Fatalf("write rekey config: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestSecret_Rekey_DecryptError(t *testing.T) {
 	dir := t.TempDir()
 	keyPath, recipient := writeTempAgeKey(t, dir)
 	cfgPath := filepath.Join(dir, "cfg.yml")
-	cfg := "docker:\n  identifier: test-id\nsops:\n  age:\n    key_file: " + keyPath + "\n  recipients:\n    - " + recipient + "\nsecrets:\n  sops:\n    - missing.env\n"
+	cfg := "docker:\n  identifier: test-id\nsops:\n  age:\n    key_file: " + keyPath + "\n    recipients:\n      - " + recipient + "\nsecrets:\n  sops:\n    - missing.env\n"
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write cfg: %v", err)
 	}

--- a/internal/cli/template.yml
+++ b/internal/cli/template.yml
@@ -13,7 +13,13 @@ environment:
 sops:
   age:
     key_file: ""
-  recipients: []
+    recipients: []
+  pgp:
+    keyring_dir: ""
+    use_agent: true
+    pinentry_mode: "default"
+    recipients: []
+    passphrase: ""
 
 secrets:
   sops: []

--- a/internal/cli/testdata/doctor/compose_missing.golden
+++ b/internal/cli/testdata/doctor/compose_missing.golden
@@ -6,9 +6,10 @@ Context: default  •  Host: unix:///var/run/docker.sock
 │ × [compose] Docker Compose (v2) — not found
 │     Remedy: Install docker compose plugin (v2+).
 │ ✓ [sops] SOPS present — sops 3.10.2
+│ ✓ [gpg] GnuPG present — installed
 │ ✓ [helper] Helper image present — alpine:3.22
 │ ✓ [net-perms] Network create/remove — ok
 │ ✓ [vol-perms] Volume create/remove — ok
 
-Summary: 7 checks • 6 PASS, 0 WARN, 1 FAIL
+Summary: 8 checks • 7 PASS, 0 WARN, 1 FAIL
 Action needed: fix the FAIL items above, then re-run: dockform doctor

--- a/internal/cli/testdata/doctor/compose_missing.golden
+++ b/internal/cli/testdata/doctor/compose_missing.golden
@@ -6,7 +6,9 @@ Context: default  •  Host: unix:///var/run/docker.sock
 │ × [compose] Docker Compose (v2) — not found
 │     Remedy: Install docker compose plugin (v2+).
 │ ✓ [sops] SOPS present — sops 3.10.2
-│ ✓ [gpg] GnuPG present — installed
+│ ✓ [gpg] GnuPG present — gpg (GnuPG) 2.4.3
+│     agent socket: /tmp/gpg-agent.sock
+│     loopback: supported
 │ ✓ [helper] Helper image present — alpine:3.22
 │ ✓ [net-perms] Network create/remove — ok
 │ ✓ [vol-perms] Volume create/remove — ok

--- a/internal/cli/testdata/doctor/engine_fail.golden
+++ b/internal/cli/testdata/doctor/engine_fail.golden
@@ -8,9 +8,12 @@ Context: default
 │ × [compose] Docker Compose (v2) — not found
 │     Remedy: Install docker compose plugin (v2+).
 │ ✓ [sops] SOPS present — sops 3.10.2
+│ ✓ [gpg] GnuPG present — gpg (GnuPG) 2.4.3
+│     agent socket: /tmp/gpg-agent.sock
+│     loopback: supported
 │ ✓ [helper] Helper image present — alpine:3.22
 │ ✓ [net-perms] Network create/remove — ok
 │ ✓ [vol-perms] Volume create/remove — ok
 
-Summary: 7 checks • 5 PASS, 0 WARN, 2 FAIL
+Summary: 8 checks • 6 PASS, 0 WARN, 2 FAIL
 Action needed: fix the FAIL items above, then re-run: dockform doctor

--- a/internal/cli/testdata/doctor/healthy.golden
+++ b/internal/cli/testdata/doctor/healthy.golden
@@ -5,7 +5,9 @@ Context: default  •  Host: unix:///var/run/docker.sock
 │ ✓ [context] Active context reachable — "default"
 │ ✓ [compose] Docker Compose plugin — 2.29.0
 │ ✓ [sops] SOPS present — sops 3.10.2
-│ ✓ [gpg] GnuPG present — installed
+│ ✓ [gpg] GnuPG present — gpg (GnuPG) 2.4.3
+│     agent socket: /tmp/gpg-agent.sock
+│     loopback: supported
 │ ✓ [helper] Helper image present — alpine:3.22
 │ ✓ [net-perms] Network create/remove — ok
 │ ✓ [vol-perms] Volume create/remove — ok

--- a/internal/cli/testdata/doctor/healthy.golden
+++ b/internal/cli/testdata/doctor/healthy.golden
@@ -5,9 +5,10 @@ Context: default  •  Host: unix:///var/run/docker.sock
 │ ✓ [context] Active context reachable — "default"
 │ ✓ [compose] Docker Compose plugin — 2.29.0
 │ ✓ [sops] SOPS present — sops 3.10.2
+│ ✓ [gpg] GnuPG present — installed
 │ ✓ [helper] Helper image present — alpine:3.22
 │ ✓ [net-perms] Network create/remove — ok
 │ ✓ [vol-perms] Volume create/remove — ok
 
-Summary: 7 checks • 7 PASS, 0 WARN, 0 FAIL
+Summary: 8 checks • 8 PASS, 0 WARN, 0 FAIL
 All good!

--- a/internal/cli/testdata/doctor/sops_warning.golden
+++ b/internal/cli/testdata/doctor/sops_warning.golden
@@ -6,9 +6,11 @@ Context: default  •  Host: unix:///var/run/docker.sock
 │ ✓ [compose] Docker Compose plugin — 2.29.0
 │ ! [sops] SOPS — not found
 │     Tip: Install SOPS to decrypt secrets: https://github.com/getsops/sops
+│ ! [gpg] GnuPG — gpg not found
+│     Tip: Install GnuPG if using PGP with SOPS.
 │ ✓ [helper] Helper image present — alpine:3.22
 │ ✓ [net-perms] Network create/remove — ok
 │ ✓ [vol-perms] Volume create/remove — ok
 
-Summary: 7 checks • 6 PASS, 1 WARN, 0 FAIL
+Summary: 8 checks • 6 PASS, 2 WARN, 0 FAIL
 Completed with warnings. Some features may be degraded.

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -49,12 +49,24 @@ type Environment struct {
 
 // SopsConfig configures SOPS provider(s)
 type SopsConfig struct {
-	Age        *SopsAgeConfig `yaml:"age"`
-	Recipients []string       `yaml:"recipients"`
+    Age        *SopsAgeConfig `yaml:"age"`
+    // Recipients is deprecated; kept for migration error messaging
+    Recipients []string       `yaml:"recipients"`
+    Pgp        *SopsPgpConfig `yaml:"pgp"`
 }
 
 type SopsAgeConfig struct {
-	KeyFile string `yaml:"key_file"`
+    KeyFile    string   `yaml:"key_file"`
+    Recipients []string `yaml:"recipients"`
+}
+
+// SopsPgpConfig configures PGP (GnuPG) backend for SOPS
+type SopsPgpConfig struct {
+    KeyringDir   string   `yaml:"keyring_dir"`
+    UseAgent     bool     `yaml:"use_agent"`
+    PinentryMode string   `yaml:"pinentry_mode"`
+    Recipients   []string `yaml:"recipients"`
+    Passphrase   string   `yaml:"passphrase"`
 }
 
 // Secrets holds secret sources

--- a/internal/planner/prune.go
+++ b/internal/planner/prune.go
@@ -19,16 +19,26 @@ func (p *Planner) Prune(ctx context.Context, cfg manifest.Config) error {
 	desiredServices := map[string]struct{}{}
 	for _, app := range cfg.Applications {
 		inline := append([]string(nil), app.EnvInline...)
-		ageKeyFile := ""
-		if cfg.Sops != nil && cfg.Sops.Age != nil {
-			ageKeyFile = cfg.Sops.Age.KeyFile
-		}
-		for _, pth0 := range app.SopsSecrets {
+        ageKeyFile := ""
+        pgpDir := ""
+        pgpAgent := false
+        pgpMode := ""
+        pgpPass := ""
+        if cfg.Sops != nil && cfg.Sops.Age != nil {
+            ageKeyFile = cfg.Sops.Age.KeyFile
+        }
+        if cfg.Sops != nil && cfg.Sops.Pgp != nil {
+            pgpDir = cfg.Sops.Pgp.KeyringDir
+            pgpAgent = cfg.Sops.Pgp.UseAgent
+            pgpMode = cfg.Sops.Pgp.PinentryMode
+            pgpPass = cfg.Sops.Pgp.Passphrase
+        }
+        for _, pth0 := range app.SopsSecrets {
 			pth := pth0
 			if pth != "" && !filepath.IsAbs(pth) {
 				pth = filepath.Join(app.Root, pth)
 			}
-			if pairs, err := secrets.DecryptAndParse(ctx, pth, ageKeyFile); err == nil {
+            if pairs, err := secrets.DecryptAndParse(ctx, pth, secrets.SopsOptions{AgeKeyFile: ageKeyFile, PgpKeyringDir: pgpDir, PgpUseAgent: pgpAgent, PgpPinentryMode: pgpMode, PgpPassphrase: pgpPass}); err == nil {
 				inline = append(inline, pairs...)
 			}
 		}

--- a/internal/secrets/encrypt.go
+++ b/internal/secrets/encrypt.go
@@ -62,11 +62,13 @@ func AgeRecipientsFromKeyFile(ageKeyFile string) ([]string, error) {
 	return recips, nil
 }
 
-// EncryptDotenvFileWithSops encrypts a plaintext dotenv file in-place using the system SOPS binary with provided age recipients.
-func EncryptDotenvFileWithSops(ctx context.Context, path string, recipients []string, ageKeyFile string) error {
-	if len(recipients) == 0 {
-		return apperr.New("secrets.EncryptDotenvFileWithSops", apperr.InvalidInput, "no recipients provided")
-	}
+// EncryptDotenvFileWithSops encrypts a plaintext dotenv file in-place using the system SOPS binary with provided recipients.
+// Age recipients are passed with --age, PGP recipients are passed with --pgp
+func EncryptDotenvFileWithSops(ctx context.Context, path string, ageRecipients []string, ageKeyFile string, pgpRecipients []string, pgpKeyringDir string, pgpUseAgent bool, pgpPinentryMode string, pgpPassphrase string) error {
+    totalRecips := len(ageRecipients) + len(pgpRecipients)
+    if totalRecips == 0 {
+        return apperr.New("secrets.EncryptDotenvFileWithSops", apperr.InvalidInput, "no recipients provided")
+    }
 	// Ensure file exists
 	if _, err := os.Stat(path); err != nil {
 		return apperr.Wrap("secrets.EncryptDotenvFileWithSops", apperr.NotFound, err, "read plaintext")
@@ -75,8 +77,8 @@ func EncryptDotenvFileWithSops(ctx context.Context, path string, recipients []st
 	if _, err := exec.LookPath("sops"); err != nil {
 		return apperr.New("secrets.EncryptDotenvFileWithSops", apperr.NotFound, "sops binary not found on PATH; please install sops")
 	}
-	// Ensure SOPS_AGE_KEY_FILE set for decrypt compatibility and environments that need it
-	if ageKeyFile != "" {
+    // Ensure SOPS_AGE_KEY_FILE set for decrypt compatibility and environments that need it
+    if ageKeyFile != "" {
 		key := ageKeyFile
 		if strings.HasPrefix(key, "~/") {
 			if home, err := os.UserHomeDir(); err == nil {
@@ -85,10 +87,23 @@ func EncryptDotenvFileWithSops(ctx context.Context, path string, recipients []st
 		}
 		_ = os.Setenv("SOPS_AGE_KEY_FILE", key)
 	}
+    // Prepare GnuPG settings if provided
+    if strings.TrimSpace(pgpKeyringDir) != "" {
+        dir := pgpKeyringDir
+        if strings.HasPrefix(dir, "~/") {
+            if home, err := os.UserHomeDir(); err == nil {
+                dir = filepath.Join(home, dir[2:])
+            }
+        }
+        _ = os.Setenv("GNUPGHOME", dir)
+        if strings.ToLower(strings.TrimSpace(pgpPinentryMode)) == "loopback" && !pgpUseAgent {
+            _ = os.Setenv("SOPS_GPG_EXEC", "gpg --pinentry-mode loopback")
+        }
+    }
 
 	// Build args with a single --age flag carrying a comma-separated list
-	validRecipients := make([]string, 0, len(recipients))
-	for _, r := range recipients {
+    validAgeRecipients := make([]string, 0, len(ageRecipients))
+    for _, r := range ageRecipients {
 		r = strings.TrimSpace(r)
 		if r == "" {
 			continue
@@ -97,17 +112,21 @@ func EncryptDotenvFileWithSops(ctx context.Context, path string, recipients []st
 		if !strings.HasPrefix(r, "age1") {
 			return apperr.New("secrets.EncryptDotenvFileWithSops", apperr.InvalidInput, "age recipient: invalid format")
 		}
-		validRecipients = append(validRecipients, r)
+        validAgeRecipients = append(validAgeRecipients, r)
 	}
 
-	args := []string{"--encrypt", "--input-type", "dotenv", "--output-type", "dotenv", "--in-place"}
-	if len(validRecipients) > 0 {
-		args = append(args, "--age", strings.Join(validRecipients, ","))
+    args := []string{"--encrypt", "--input-type", "dotenv", "--output-type", "dotenv", "--in-place"}
+    if len(validAgeRecipients) > 0 {
+        args = append(args, "--age", strings.Join(validAgeRecipients, ","))
 	}
+    if len(pgpRecipients) > 0 {
+        // pass pgp recipients directly; validation is deferred to gpg
+        args = append(args, "--pgp", strings.Join(pgpRecipients, ","))
+    }
 	args = append(args, path)
-	cmd := exec.CommandContext(ctx, "sops", args...)
-	cmd.Env = os.Environ()
-	if out, err := cmd.CombinedOutput(); err != nil {
+    cmd := exec.CommandContext(ctx, "sops", args...)
+    cmd.Env = os.Environ()
+    if out, err := cmd.CombinedOutput(); err != nil {
 		return apperr.Wrap("secrets.EncryptDotenvFileWithSops", apperr.External, errors.New(string(out)), "sops encrypt %s", path)
 	}
 	return nil

--- a/internal/secrets/encrypt_test.go
+++ b/internal/secrets/encrypt_test.go
@@ -68,7 +68,7 @@ func TestEncryptDotenvFileWithSops_Success_AndDecryptable(t *testing.T) {
 	if err := os.WriteFile(path, []byte(plain), 0o600); err != nil {
 		t.Fatalf("write plaintext: %v", err)
 	}
-	if err := EncryptDotenvFileWithSops(context.Background(), path, []string{recip}, keyPath); err != nil {
+    if err := EncryptDotenvFileWithSops(context.Background(), path, []string{recip}, keyPath, nil, "", false, "", ""); err != nil {
 		t.Fatalf("encrypt: %v", err)
 	}
 	// file should not contain plaintext
@@ -93,7 +93,7 @@ func TestEncryptDotenvFileWithSops_NoRecipients_Error(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "x.env")
 	_ = os.WriteFile(path, []byte("K=V\n"), 0o600)
-	if err := EncryptDotenvFileWithSops(context.Background(), path, nil, ""); err == nil {
+    if err := EncryptDotenvFileWithSops(context.Background(), path, nil, "", nil, "", false, "", ""); err == nil {
 		t.Fatalf("expected error for no recipients, got nil")
 	}
 }
@@ -102,7 +102,7 @@ func TestEncryptDotenvFileWithSops_BadRecipient_Error(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "x.env")
 	_ = os.WriteFile(path, []byte("K=V\n"), 0o600)
-	if err := EncryptDotenvFileWithSops(context.Background(), path, []string{"not-a-valid-recipient"}, ""); err == nil || !strings.Contains(err.Error(), "age recipient") {
+    if err := EncryptDotenvFileWithSops(context.Background(), path, []string{"not-a-valid-recipient"}, "", nil, "", false, "", ""); err == nil || !strings.Contains(err.Error(), "age recipient") {
 		t.Fatalf("expected age recipient error, got %v", err)
 	}
 }

--- a/internal/secrets/sops.go
+++ b/internal/secrets/sops.go
@@ -1,75 +1,125 @@
 package secrets
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
+    "context"
+    "errors"
+    "fmt"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
 
-	"github.com/gcstr/dockform/internal/apperr"
+    "github.com/gcstr/dockform/internal/apperr"
 )
 
+// SopsOptions provides decryption/encryption settings for SOPS (age + pgp)
+type SopsOptions struct {
+    // Age
+    AgeKeyFile    string
+    AgeRecipients []string
+    // PGP (GnuPG)
+    PgpKeyringDir   string
+    PgpUseAgent     bool
+    PgpPinentryMode string // "default" | "loopback"
+    PgpPassphrase   string // interpolated already; not logged
+    PgpRecipients   []string
+}
+
 // DecryptAndParse returns key=value pairs from a SOPS-encrypted dotenv file.
-// Only dotenv format is supported. If ageKeyFile is empty, the file is treated as plaintext.
-func DecryptAndParse(ctx context.Context, path string, ageKeyFile string) ([]string, error) {
-	// If no age key file is specified, treat the file as plaintext
-	if ageKeyFile == "" {
-		b, err := os.ReadFile(path)
-		if err != nil {
-			return nil, apperr.Wrap("secrets.DecryptAndParse", apperr.NotFound, err, "read plaintext file %s", path)
-		}
-		return parseDotenv(string(b)), nil
-	}
+// Only dotenv format is supported. If no SOPS backends are configured, the file is treated as plaintext.
+func DecryptAndParse(ctx context.Context, path string, opts SopsOptions) ([]string, error) {
+    // If neither Age nor PGP is configured, treat as plaintext
+    if strings.TrimSpace(opts.AgeKeyFile) == "" && strings.TrimSpace(opts.PgpKeyringDir) == "" {
+        b, err := os.ReadFile(path)
+        if err != nil {
+            return nil, apperr.Wrap("secrets.DecryptAndParse", apperr.NotFound, err, "read plaintext file %s", path)
+        }
+        return parseDotenv(string(b)), nil
+    }
 
-	// Resolve home dir for key file if starts with ~/
-	unset := false
-	key := ageKeyFile
-	if strings.HasPrefix(key, "~/") {
-		if home, err := os.UserHomeDir(); err == nil {
-			key = filepath.Join(home, key[2:])
-		}
-	}
-	prev := os.Getenv("SOPS_AGE_KEY_FILE")
-	if prev == "" {
-		unset = true
-	}
-	_ = os.Setenv("SOPS_AGE_KEY_FILE", key)
-	// Also set SOPS_AGE_KEY for environments where sops reads the key from env
-	if b, rerr := os.ReadFile(key); rerr == nil {
-		prevKey := os.Getenv("SOPS_AGE_KEY")
-		_ = os.Setenv("SOPS_AGE_KEY", string(b))
-		if prevKey == "" {
-			defer func() { _ = os.Unsetenv("SOPS_AGE_KEY") }()
-		} else {
-			defer func() { _ = os.Setenv("SOPS_AGE_KEY", prevKey) }()
-		}
-	}
-	if unset {
-		defer func() { _ = os.Unsetenv("SOPS_AGE_KEY_FILE") }()
-	} else {
-		defer func() { _ = os.Setenv("SOPS_AGE_KEY_FILE", prev) }()
-	}
+    // Prepare environment for SOPS/AGE
+    // Resolve home dir for key file if starts with ~/
+    if strings.TrimSpace(opts.AgeKeyFile) != "" {
+        unset := false
+        key := opts.AgeKeyFile
+        if strings.HasPrefix(key, "~/") {
+            if home, err := os.UserHomeDir(); err == nil {
+                key = filepath.Join(home, key[2:])
+            }
+        }
+        prev := os.Getenv("SOPS_AGE_KEY_FILE")
+        if prev == "" {
+            unset = true
+        }
+        _ = os.Setenv("SOPS_AGE_KEY_FILE", key)
+        // Also set SOPS_AGE_KEY for environments where sops reads the key from env
+        if b, rerr := os.ReadFile(key); rerr == nil {
+            prevKey := os.Getenv("SOPS_AGE_KEY")
+            _ = os.Setenv("SOPS_AGE_KEY", string(b))
+            if prevKey == "" {
+                defer func() { _ = os.Unsetenv("SOPS_AGE_KEY") }()
+            } else {
+                defer func() { _ = os.Setenv("SOPS_AGE_KEY", prevKey) }()
+            }
+        }
+        if unset {
+            defer func() { _ = os.Unsetenv("SOPS_AGE_KEY_FILE") }()
+        } else {
+            defer func() { _ = os.Setenv("SOPS_AGE_KEY_FILE", prev) }()
+        }
+    }
 
-	// Ensure sops binary exists
-	if _, err := exec.LookPath("sops"); err != nil {
-		return nil, apperr.New("secrets.DecryptAndParse", apperr.NotFound, "sops binary not found on PATH; please install sops")
-	}
+    // Prepare environment for SOPS/PGP (GnuPG)
+    if strings.TrimSpace(opts.PgpKeyringDir) != "" {
+        // Expand ~/
+        dir := opts.PgpKeyringDir
+        if strings.HasPrefix(dir, "~/") {
+            if home, err := os.UserHomeDir(); err == nil {
+                dir = filepath.Join(home, dir[2:])
+            }
+        }
+        prev := os.Getenv("GNUPGHOME")
+        _ = os.Setenv("GNUPGHOME", dir)
+        defer func() {
+            if prev == "" {
+                _ = os.Unsetenv("GNUPGHOME")
+            } else {
+                _ = os.Setenv("GNUPGHOME", prev)
+            }
+        }()
 
-	// Decrypt file using system sops
-	cmd := exec.CommandContext(ctx, "sops", "--decrypt", "--input-type", "dotenv", path)
-	cmd.Env = os.Environ()
-	out, err := cmd.Output()
-	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
-			return nil, apperr.Wrap("secrets.DecryptAndParse", apperr.External, errors.New(string(ee.Stderr)), "sops decrypt %s", path)
-		}
-		return nil, apperr.Wrap("secrets.DecryptAndParse", apperr.External, err, "sops decrypt %s", path)
-	}
+        // Loopback handling: request loopback mode if configured
+        if strings.ToLower(strings.TrimSpace(opts.PgpPinentryMode)) == "loopback" && !opts.PgpUseAgent {
+            prevExec := os.Getenv("SOPS_GPG_EXEC")
+            // append loopback flag; rely on gpg inheriting STDIN; passphrase may still be required by gpg
+            _ = os.Setenv("SOPS_GPG_EXEC", "gpg --pinentry-mode loopback")
+            defer func() {
+                if prevExec == "" {
+                    _ = os.Unsetenv("SOPS_GPG_EXEC")
+                } else {
+                    _ = os.Setenv("SOPS_GPG_EXEC", prevExec)
+                }
+            }()
+        }
+    }
 
-	return parseDotenv(string(out)), nil
+    // Ensure sops binary exists
+    if _, err := exec.LookPath("sops"); err != nil {
+        return nil, apperr.New("secrets.DecryptAndParse", apperr.NotFound, "sops binary not found on PATH; please install sops")
+    }
+
+    // Decrypt file using system sops
+    cmd := exec.CommandContext(ctx, "sops", "--decrypt", "--input-type", "dotenv", path)
+    cmd.Env = os.Environ()
+    out, err := cmd.Output()
+    if err != nil {
+        if ee, ok := err.(*exec.ExitError); ok {
+            return nil, apperr.Wrap("secrets.DecryptAndParse", apperr.External, errors.New(string(ee.Stderr)), "sops decrypt %s", path)
+        }
+        return nil, apperr.Wrap("secrets.DecryptAndParse", apperr.External, err, "sops decrypt %s", path)
+    }
+
+    return parseDotenv(string(out)), nil
 }
 
 func parseDotenv(s string) []string {

--- a/internal/secrets/sops_test.go
+++ b/internal/secrets/sops_test.go
@@ -20,11 +20,11 @@ func TestDecryptAndParse_Dotenv_Success(t *testing.T) {
 	if err := os.WriteFile(plainPath, []byte("FOO=bar\nBAZ='qux'\n"), 0o600); err != nil {
 		t.Fatalf("write plaintext: %v", err)
 	}
-	if err := EncryptDotenvFileWithSops(context.Background(), plainPath, []string{recip}, keyPath); err != nil {
+    if err := EncryptDotenvFileWithSops(context.Background(), plainPath, []string{recip}, keyPath, nil, "", false, "", ""); err != nil {
 		t.Fatalf("encrypt: %v", err)
 	}
 	// Now decrypt via DecryptAndParse
-	pairs, err := DecryptAndParse(context.Background(), plainPath, keyPath)
+    pairs, err := DecryptAndParse(context.Background(), plainPath, SopsOptions{AgeKeyFile: keyPath})
 	if err != nil {
 		t.Fatalf("DecryptAndParse: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestDecryptAndParse_MissingFile_Error(t *testing.T) {
 	requireSops(t)
 	dir := t.TempDir()
 	keyPath, _ := writeTempAgeKey(t, dir, true)
-	if _, err := DecryptAndParse(context.Background(), filepath.Join(dir, "missing.env"), keyPath); err == nil {
+    if _, err := DecryptAndParse(context.Background(), filepath.Join(dir, "missing.env"), SopsOptions{AgeKeyFile: keyPath}); err == nil {
 		t.Fatalf("expected decrypt error for missing file")
 	}
 }
@@ -50,7 +50,7 @@ func TestDecryptAndParse_PlaintextWhenEmptyKeyFile(t *testing.T) {
 		t.Fatalf("write plaintext: %v", err)
 	}
 	// Call DecryptAndParse with empty ageKeyFile
-	pairs, err := DecryptAndParse(context.Background(), plainPath, "")
+    pairs, err := DecryptAndParse(context.Background(), plainPath, SopsOptions{})
 	if err != nil {
 		t.Fatalf("DecryptAndParse with empty key file: %v", err)
 	}

--- a/test/e2e/testdata/scenarios/example/dockform.yml
+++ b/test/e2e/testdata/scenarios/example/dockform.yml
@@ -18,11 +18,11 @@ filesets:
 sops:
   age:
     key_file: ${AGE_KEY_FILE}
-  recipients:
-    - age1vmn3nv333mprv02cn8qyafxaz94zg368lnk5gsclmme9ryludysswn5rgr
-    - age1g39p42mle5uva3tqns37dmjy5znqyftfav0ldccxy7we9hh9vdlqzeyd7g
-    - age1uyu44nt7l8cupegcyamasfhv023jrhylc4gxv8nq3y434k40y35swcu595
-    - age1qdmqmutxujygy9fm68vkymu0yypr2kgly9dx5ewezpcpzfh6mv7qja3n6x
+    recipients:
+      - age1vmn3nv333mprv02cn8qyafxaz94zg368lnk5gsclmme9ryludysswn5rgr
+      - age1g39p42mle5uva3tqns37dmjy5znqyftfav0ldccxy7we9hh9vdlqzeyd7g
+      - age1uyu44nt7l8cupegcyamasfhv023jrhylc4gxv8nq3y434k40y35swcu595
+      - age1qdmqmutxujygy9fm68vkymu0yypr2kgly9dx5ewezpcpzfh6mv7qja3n6x
 
 secrets:
   sops:


### PR DESCRIPTION
Adds support for encrypting and decrypting secrets using PGP keys, in addition to existing age key support.

Key changes include:
- Adds GnuPG (GPG) presence check to the `doctor` command.
- Updates SOPS decryption logic to incorporate PGP keyring directory, agent usage, pinentry mode, and passphrase settings.
- Updates the `secret` commands to integrate PGP options.
- Updates manifest to include PGP configuration options.

Closes #4