### PR TITLE
feat: Handles interrupt signals for graceful shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ Thumbs.db
 .sops.yaml
 
 example/website/assets/
+
+.gocache/

--- a/cmd/dockform/main.go
+++ b/cmd/dockform/main.go
@@ -1,11 +1,26 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/gcstr/dockform/internal/cli"
 )
 
 func main() {
-	os.Exit(cli.Execute())
+	// Create a context that cancels on SIGINT or SIGTERM
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Set up signal handling
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	os.Exit(cli.Execute(ctx))
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -124,13 +125,13 @@ func TestExecute_ReturnCodes_ByErrorKind(t *testing.T) {
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 	os.Args = []string{"dockform", "validate", "-c", badFile.Name()}
-	if code := Execute(); code != 2 {
+	if code := Execute(context.Background()); code != 2 {
 		t.Fatalf("expected exit code 2 for invalid input, got %d", code)
 	}
 
 	// NotFound default mapping -> 1
 	os.Args = []string{"dockform", "validate", "-c", "/path/does/not/exist.yml"}
-	if code := Execute(); code != 1 {
+	if code := Execute(context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1 for not found, got %d", code)
 	}
 
@@ -138,7 +139,7 @@ func TestExecute_ReturnCodes_ByErrorKind(t *testing.T) {
 	defer withFailingDockerRoot(t)()
 	cfg := basicConfigPath(t)
 	os.Args = []string{"dockform", "validate", "-c", cfg}
-	if code := Execute(); code != 69 {
+	if code := Execute(context.Background()); code != 69 {
 		t.Fatalf("expected exit code 69 for unavailable, got %d", code)
 	}
 }

--- a/internal/dockercli/dockercli.go
+++ b/internal/dockercli/dockercli.go
@@ -35,6 +35,10 @@ func (c *Client) WithIdentifier(id string) *Client {
 // CheckDaemon verifies the docker daemon for the configured context is reachable.
 func (c *Client) CheckDaemon(ctx context.Context) error {
 	if _, err := c.exec.Run(ctx, "version", "--format", "{{.Server.Version}}"); err != nil {
+		// Check if this is a context cancellation error - if so, return it directly
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if c.contextName != "" && c.contextName != "default" {
 			return apperr.Wrap("dockercli.CheckDaemon", apperr.Unavailable, err, "docker daemon not reachable (context=%s)", c.contextName)
 		}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -19,6 +19,10 @@ import (
 func Validate(ctx context.Context, cfg manifest.Config, d *dockercli.Client) error {
 	// 1) Docker daemon liveness
 	if err := d.CheckDaemon(ctx); err != nil {
+		// Check if this is a context cancellation - if so, return it directly
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return err
 	}
 
@@ -97,6 +101,10 @@ func Validate(ctx context.Context, cfg manifest.Config, d *dockercli.Client) err
 
 		// Validate compose file syntax by attempting to parse it with Docker
 		if _, err := d.ComposeConfigFull(ctx, app.Root, app.Files, app.Profiles, []string{}, []string{}); err != nil {
+			// Check if this is a context cancellation error - if so, return it directly
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			if len(app.Files) == 1 {
 				return apperr.Wrap("validator.Validate", apperr.External, err, "invalid compose file %s for application %s", app.Files[0], appName)
 			} else if len(app.Files) > 1 {


### PR DESCRIPTION
Adds interrupt signal handling (SIGINT/SIGTERM) to allow for graceful shutdown.

- Introduces a context that is cancelled when an interrupt signal is received.
- Propagates this context to relevant functions to enable cancellation of ongoing operations.
- Returns an exit code of 130 when the application is interrupted.