### PR TITLE
feat: Displays version in doctor command output

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -83,7 +83,7 @@ func newDoctorCmd() *cobra.Command {
 
 			// Render
 			// Top header
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Dockform Doctor — health scan")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Dockform (v%s) Doctor — health scan\n", version)
 			if host != "" {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Context: %s  •  Host: %s\n\n", ctxName, host)
 			} else {

--- a/internal/cli/doctor_scenarios_test.go
+++ b/internal/cli/doctor_scenarios_test.go
@@ -25,7 +25,7 @@ func TestDoctorCmd_AllHealthy(t *testing.T) {
 	output := out.String()
 
 	// Check header
-	if !strings.Contains(output, "Dockform Doctor") {
+	if !strings.Contains(output, "Doctor — health scan") {
 		t.Errorf("missing header, got: %q", output)
 	}
 	if !strings.Contains(output, "Context: default") {

--- a/internal/cli/testdata/doctor/compose_missing.golden
+++ b/internal/cli/testdata/doctor/compose_missing.golden
@@ -1,4 +1,4 @@
-Dockform Doctor — health scan
+Dockform (v0.1.0-dev) Doctor — health scan
 Context: default  •  Host: unix:///var/run/docker.sock
 
 │ ✓ [engine] Docker Engine reachable — v20.0.0

--- a/internal/cli/testdata/doctor/engine_fail.golden
+++ b/internal/cli/testdata/doctor/engine_fail.golden
@@ -1,4 +1,4 @@
-Dockform Doctor — health scan
+Dockform (v0.1.0-dev) Doctor — health scan
 Context: default
 
 │ × [engine] Docker Engine reachable — daemon not reachable

--- a/internal/cli/testdata/doctor/healthy.golden
+++ b/internal/cli/testdata/doctor/healthy.golden
@@ -1,4 +1,4 @@
-Dockform Doctor — health scan
+Dockform (v0.1.0-dev) Doctor — health scan
 Context: default  •  Host: unix:///var/run/docker.sock
 
 │ ✓ [engine] Docker Engine reachable — v20.0.0

--- a/internal/cli/testdata/doctor/sops_warning.golden
+++ b/internal/cli/testdata/doctor/sops_warning.golden
@@ -1,4 +1,4 @@
-Dockform Doctor — health scan
+Dockform (v0.1.0-dev) Doctor — health scan
 Context: default  •  Host: unix:///var/run/docker.sock
 
 │ ✓ [engine] Docker Engine reachable — v20.0.0


### PR DESCRIPTION
Adds the application version to the output of the `doctor` command. This provides users with more context about the environment being diagnosed.