### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gcstr/dockform/security/code-scanning/3](https://github.com/gcstr/dockform/security/code-scanning/3)

To fix this security issue, specify a `permissions` block in the workflow. This can be most efficiently done at the workflow root, before the `jobs:` key, so all jobs inherit strict permissions (e.g., `contents: read`), following the principle of least privilege. This prevents accidental escalations if workflow defaults change or new jobs are added. The only edit needed is to insert:
```yaml
permissions:
  contents: read
```
immediately before the `jobs:` key in `.github/workflows/ci.yml`.

No additional definitions, external packages, or imports are required for this change. Should any future job or step require elevated permissions, a more permissive or tailored `permissions:` block can be added for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
