### PR TITLE
feat: Adds fileset ownership support

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -289,10 +289,15 @@ func checkHelperImage(ctx context.Context, docker *dockercli.Client) checkResult
 		// Non-fatal; treat as warn because registry may be offline
 		return checkResult{id: "helper", title: "Helper image", status: statusWarn, summary: fmt.Sprintf("check failed — %s", strings.TrimSpace(err.Error())), note: "Note: Could not verify helper image presence."}
 	}
-	if exists {
-		return checkResult{id: "helper", title: "Helper image present", status: statusPass, summary: img}
+	if !exists {
+		return checkResult{id: "helper", title: "Helper image missing", status: statusWarn, summary: img, note: "Note: Skipped pulling (no registry access). Run again when online."}
 	}
-	return checkResult{id: "helper", title: "Helper image missing", status: statusWarn, summary: img, note: "Note: Skipped pulling (no registry access). Run again when online."}
+
+	// Image exists - alpine:3.22 includes all required binaries by default
+	// (sh, find, xargs, getent, chown, chmod, cut)
+	var sub []string
+	sub = append(sub, "provides: sh, find, xargs, getent, chown, chmod, cut")
+	return checkResult{id: "helper", title: "Helper image ready", status: statusPass, summary: img, sub: sub}
 }
 
 func checkNetworkPerms(ctx context.Context, docker *dockercli.Client) checkResult {

--- a/internal/cli/testdata/doctor/compose_missing.golden
+++ b/internal/cli/testdata/doctor/compose_missing.golden
@@ -9,7 +9,8 @@ Context: default  •  Host: unix:///var/run/docker.sock
 │ ✓ [gpg] GnuPG present — gpg (GnuPG) 2.4.3
 │     agent socket: /tmp/gpg-agent.sock
 │     loopback: supported
-│ ✓ [helper] Helper image present — alpine:3.22
+│ ✓ [helper] Helper image ready — alpine:3.22
+│     provides: sh, find, xargs, getent, chown, chmod, cut
 │ ✓ [net-perms] Network create/remove — ok
 │ ✓ [vol-perms] Volume create/remove — ok
 

--- a/internal/cli/testdata/doctor/engine_fail.golden
+++ b/internal/cli/testdata/doctor/engine_fail.golden
@@ -11,7 +11,8 @@ Context: default
 │ ✓ [gpg] GnuPG present — gpg (GnuPG) 2.4.3
 │     agent socket: /tmp/gpg-agent.sock
 │     loopback: supported
-│ ✓ [helper] Helper image present — alpine:3.22
+│ ✓ [helper] Helper image ready — alpine:3.22
+│     provides: sh, find, xargs, getent, chown, chmod, cut
 │ ✓ [net-perms] Network create/remove — ok
 │ ✓ [vol-perms] Volume create/remove — ok
 

--- a/internal/cli/testdata/doctor/healthy.golden
+++ b/internal/cli/testdata/doctor/healthy.golden
@@ -8,7 +8,8 @@ Context: default  •  Host: unix:///var/run/docker.sock
 │ ✓ [gpg] GnuPG present — gpg (GnuPG) 2.4.3
 │     agent socket: /tmp/gpg-agent.sock
 │     loopback: supported
-│ ✓ [helper] Helper image present — alpine:3.22
+│ ✓ [helper] Helper image ready — alpine:3.22
+│     provides: sh, find, xargs, getent, chown, chmod, cut
 │ ✓ [net-perms] Network create/remove — ok
 │ ✓ [vol-perms] Volume create/remove — ok
 

--- a/internal/cli/testdata/doctor/sops_warning.golden
+++ b/internal/cli/testdata/doctor/sops_warning.golden
@@ -8,7 +8,8 @@ Context: default  •  Host: unix:///var/run/docker.sock
 │     Tip: Install SOPS to decrypt secrets: https://github.com/getsops/sops
 │ ! [gpg] GnuPG — gpg not found
 │     Tip: Install GnuPG if using PGP with SOPS.
-│ ✓ [helper] Helper image present — alpine:3.22
+│ ✓ [helper] Helper image ready — alpine:3.22
+│     provides: sh, find, xargs, getent, chown, chmod, cut
 │ ✓ [net-perms] Network create/remove — ok
 │ ✓ [vol-perms] Volume create/remove — ok
 

--- a/internal/dockercli/compose_test.go
+++ b/internal/dockercli/compose_test.go
@@ -48,6 +48,10 @@ func (f *fakeExec) RunWithStdout(ctx context.Context, stdout io.Writer, args ...
 	f.lastArgs = args
 	return nil
 }
+func (f *fakeExec) RunDetailed(ctx context.Context, opts Options, args ...string) (Result, error) {
+	out, err := f.dispatch(args)
+	return Result{Stdout: out, Stderr: "", ExitCode: 0}, err
+}
 func (f *fakeExec) dispatch(args []string) (string, error) {
 	if hasSuffix(args, []string{"config", "--services"}) {
 		return f.outServices, f.errServices

--- a/internal/dockercli/dockercli_test.go
+++ b/internal/dockercli/dockercli_test.go
@@ -68,6 +68,10 @@ func (e *execStub) RunWithStdout(ctx context.Context, stdout io.Writer, args ...
 	}
 	return nil
 }
+func (e *execStub) RunDetailed(ctx context.Context, opts Options, args ...string) (Result, error) {
+	out, err := e.Run(ctx, args...)
+	return Result{Stdout: out, Stderr: "", ExitCode: 0}, err
+}
 
 func TestCheckDaemon_SuccessAndFailure(t *testing.T) {
 	stub := &execStub{}

--- a/internal/dockercli/exec.go
+++ b/internal/dockercli/exec.go
@@ -23,6 +23,8 @@ type Exec interface {
 	// RunWithStdout streams the stdout of the docker command to the provided writer without buffering it in memory.
 	// Stderr is still captured and included in any returned error for debuggability.
 	RunWithStdout(ctx context.Context, stdout io.Writer, args ...string) error
+	// RunDetailed runs a command and returns structured Result with stdout, stderr, and exit code.
+	RunDetailed(ctx context.Context, opts Options, args ...string) (Result, error)
 }
 
 // SystemExec is a real implementation that shells out to the docker CLI.

--- a/internal/dockercli/networks_test.go
+++ b/internal/dockercli/networks_test.go
@@ -30,6 +30,10 @@ func (n *netExecStub) RunWithStdout(ctx context.Context, stdout io.Writer, args 
 	n.lastArgs = args
 	return nil
 }
+func (n *netExecStub) RunDetailed(ctx context.Context, opts Options, args ...string) (Result, error) {
+	out, err := n.Run(ctx, args...)
+	return Result{Stdout: out, Stderr: "", ExitCode: 0}, err
+}
 
 func TestListNetworks_ParsesAndFilters(t *testing.T) {
 	stub := &netExecStub{}

--- a/internal/dockercli/volumes_test.go
+++ b/internal/dockercli/volumes_test.go
@@ -32,6 +32,10 @@ func (v *volExecStub) RunWithStdout(ctx context.Context, stdout io.Writer, args 
 	v.lastArgs = args
 	return nil
 }
+func (v *volExecStub) RunDetailed(ctx context.Context, opts Options, args ...string) (Result, error) {
+	out, err := v.Run(ctx, args...)
+	return Result{Stdout: out, Stderr: "", ExitCode: 0}, err
+}
 
 // ---- Extended tests merged from volumes_more_test.go ----
 
@@ -84,6 +88,10 @@ func (s *scriptExec) RunWithStdout(ctx context.Context, stdout io.Writer, args .
 		return s.onRunWithStdout(args, stdout)
 	}
 	return nil
+}
+func (s *scriptExec) RunDetailed(ctx context.Context, opts Options, args ...string) (Result, error) {
+	out, err := s.Run(ctx, args...)
+	return Result{Stdout: out, Stderr: "", ExitCode: 0}, err
 }
 
 func TestInspectVolume_ParsesJSON(t *testing.T) {

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -90,6 +90,15 @@ type NetworkSpec struct {
 	AuxAddresses map[string]string `yaml:"aux_addresses"`
 }
 
+// Ownership defines optional ownership and permission settings for fileset files.
+type Ownership struct {
+	User             string `yaml:"user"`              // numeric UID string preferred; allow names
+	Group            string `yaml:"group"`             // numeric GID string preferred; allow names
+	FileMode         string `yaml:"file_mode"`         // octal string "0644" or "644"
+	DirMode          string `yaml:"dir_mode"`          // octal string "0755" or "755"
+	PreserveExisting bool   `yaml:"preserve_existing"` // if true, only apply to new/updated paths
+}
+
 // FilesetSpec defines a local directory to sync into a docker volume at a target path.
 type FilesetSpec struct {
 	Source          string         `yaml:"source"`
@@ -98,6 +107,7 @@ type FilesetSpec struct {
 	RestartServices RestartTargets `yaml:"restart_services"`
 	ApplyMode       string         `yaml:"apply_mode"`
 	Exclude         []string       `yaml:"exclude"`
+	Ownership       *Ownership     `yaml:"ownership"`
 	SourceAbs       string         `yaml:"-"`
 }
 

--- a/internal/planner/apply_filesets.go
+++ b/internal/planner/apply_filesets.go
@@ -3,7 +3,9 @@ package planner
 import (
 	"bytes"
 	"context"
+	"path"
 	"sort"
+	"strings"
 
 	"github.com/gcstr/dockform/internal/apperr"
 	"github.com/gcstr/dockform/internal/filesets"
@@ -127,6 +129,11 @@ func (fm *FilesetManager) SyncFilesets(ctx context.Context, cfg manifest.Config,
 			return nil, st.Fail(err)
 		}
 
+		// Apply ownership if configured
+		if err := fm.applyOwnership(ctx, name, fileset, diff); err != nil {
+			return nil, st.Fail(err)
+		}
+
 		// For cold mode, start previously stopped containers again
 		if isCold && len(stoppedContainers) > 0 {
 			if fm.progress != nil {
@@ -221,4 +228,267 @@ func (fm *FilesetManager) writeFilesetIndex(ctx context.Context, name string, fi
 	}
 
 	return nil
+}
+
+// applyOwnership applies ownership and permission settings to fileset files after they are synced.
+func (fm *FilesetManager) applyOwnership(ctx context.Context, name string, fileset manifest.FilesetSpec, diff filesets.Diff) error {
+	log := logger.FromContext(ctx).With("component", "fileset")
+
+	// Skip if no ownership configured
+	if fileset.Ownership == nil {
+		return nil
+	}
+
+	ownership := fileset.Ownership
+
+	// Skip if nothing is set
+	if ownership.User == "" && ownership.Group == "" && ownership.FileMode == "" && ownership.DirMode == "" {
+		return nil
+	}
+
+	if fm.progress != nil {
+		fm.progress.SetAction("applying ownership for fileset " + name)
+	}
+
+	// Build the script to run in the helper container
+	script, err := buildOwnershipScript(fileset.TargetPath, ownership, diff)
+	if err != nil {
+		return apperr.Wrap("filesetmanager.applyOwnership", apperr.Internal, err, "build ownership script for %s", name)
+	}
+
+	// Execute the script
+	result, err := fm.docker.RunVolumeScript(ctx, fileset.TargetVolume, fileset.TargetPath, script, nil)
+	if err != nil {
+		log.Warn("ownership application failed", "fileset", name, "error", err.Error())
+		if result.Stderr != "" {
+			log.Warn("ownership script stderr", "fileset", name, "stderr", result.Stderr)
+		}
+		return apperr.Wrap("filesetmanager.applyOwnership", apperr.External, err, "apply ownership for fileset %s", name)
+	}
+
+	// Log warnings from stdout if any
+	if result.Stdout != "" {
+		for _, line := range util.SplitNonEmptyLines(result.Stdout) {
+			if strings.Contains(strings.ToLower(line), "warning") || strings.Contains(strings.ToLower(line), "error") {
+				log.Warn("ownership script output", "fileset", name, "message", line)
+			}
+		}
+	}
+
+	// Log all stderr output (warnings go here)
+	if result.Stderr != "" {
+		for _, line := range util.SplitNonEmptyLines(result.Stderr) {
+			log.Warn("ownership script warning", "fileset", name, "message", line)
+		}
+	}
+
+	// Count operations for logging
+	filesChanged := 0
+	dirsChanged := 0
+	if ownership.PreserveExisting {
+		filesChanged = len(diff.ToCreate) + len(diff.ToUpdate)
+		// Count directories in the changed paths
+		seen := make(map[string]struct{})
+		for _, f := range diff.ToCreate {
+			dir := util.DirPath(f.Path)
+			if dir != "" && dir != "." {
+				seen[dir] = struct{}{}
+			}
+		}
+		for _, f := range diff.ToUpdate {
+			dir := util.DirPath(f.Path)
+			if dir != "" && dir != "." {
+				seen[dir] = struct{}{}
+			}
+		}
+		dirsChanged = len(seen)
+	}
+
+	log.Info("ownership applied",
+		"fileset", name,
+		"preserve_existing", ownership.PreserveExisting,
+		"files_affected", filesChanged,
+		"dirs_affected", dirsChanged)
+
+	return nil
+}
+
+// buildOwnershipScript generates a shell script to apply ownership and permissions.
+// The script operates on paths at targetPath (the volume is mounted there by RunVolumeScript).
+func buildOwnershipScript(targetPath string, ownership *manifest.Ownership, diff filesets.Diff) (string, error) {
+	// Validate target path safety
+	cleanPath := path.Clean(targetPath)
+	if cleanPath == "/" || cleanPath == "." {
+		return "", apperr.New("planner.buildOwnershipScript", apperr.InvalidInput, "unsafe target path: %s", targetPath)
+	}
+	if strings.Contains(cleanPath, "..") {
+		return "", apperr.New("planner.buildOwnershipScript", apperr.InvalidInput, "target path contains ..: %s", targetPath)
+	}
+
+	// The volume is mounted at targetPath in the helper container (same as ExtractTarToVolume)
+	rootPath := cleanPath
+
+	var script strings.Builder
+	script.WriteString("set -e\n") // Exit on error
+
+	// Resolve user and group IDs
+	var uid, gid string
+	if ownership.User != "" {
+		script.WriteString("# Resolve user ID\n")
+		// Check if numeric
+		if isNumeric(ownership.User) {
+			uid = ownership.User
+			script.WriteString("UID_VAL='" + shellEscape(uid) + "'\n")
+		} else {
+			// Try to resolve name (escape the username)
+			escapedUser := shellEscape(ownership.User)
+			script.WriteString("if getent passwd '" + escapedUser + "' >/dev/null 2>&1; then\n")
+			script.WriteString("  UID_VAL=$(getent passwd '" + escapedUser + "' | cut -d: -f3)\n")
+			script.WriteString("else\n")
+			script.WriteString("  echo 'WARNING: user \"" + escapedUser + "\" not found in helper image; skipping chown'\n")
+			script.WriteString("  UID_VAL=''\n")
+			script.WriteString("fi\n")
+		}
+	}
+
+	if ownership.Group != "" {
+		script.WriteString("# Resolve group ID\n")
+		if isNumeric(ownership.Group) {
+			gid = ownership.Group
+			script.WriteString("GID_VAL='" + shellEscape(gid) + "'\n")
+		} else {
+			// Try to resolve name (escape the group name)
+			escapedGroup := shellEscape(ownership.Group)
+			script.WriteString("if getent group '" + escapedGroup + "' >/dev/null 2>&1; then\n")
+			script.WriteString("  GID_VAL=$(getent group '" + escapedGroup + "' | cut -d: -f3)\n")
+			script.WriteString("else\n")
+			script.WriteString("  echo 'WARNING: group \"" + escapedGroup + "\" not found in helper image; skipping chown'\n")
+			script.WriteString("  GID_VAL=''\n")
+			script.WriteString("fi\n")
+		}
+	}
+
+	// Determine paths to operate on
+	if ownership.PreserveExisting {
+		// Build list of updated files and directories
+		updatedFiles := []string{}
+		updatedDirs := map[string]struct{}{}
+
+		for _, f := range diff.ToCreate {
+			fullPath := path.Join(rootPath, f.Path)
+			updatedFiles = append(updatedFiles, fullPath)
+			// Add parent directories
+			dir := path.Dir(fullPath)
+			for dir != rootPath && dir != "/mnt" && dir != "/" {
+				updatedDirs[dir] = struct{}{}
+				dir = path.Dir(dir)
+			}
+		}
+		for _, f := range diff.ToUpdate {
+			fullPath := path.Join(rootPath, f.Path)
+			updatedFiles = append(updatedFiles, fullPath)
+			// Add parent directories
+			dir := path.Dir(fullPath)
+			for dir != rootPath && dir != "/mnt" && dir != "/" {
+				updatedDirs[dir] = struct{}{}
+				dir = path.Dir(dir)
+			}
+		}
+
+		// Apply directory mode to updated directories
+		if ownership.DirMode != "" && len(updatedDirs) > 0 {
+			script.WriteString("# Apply directory mode to updated directories\n")
+			escapedDirMode := shellEscape(ownership.DirMode)
+			for dir := range updatedDirs {
+				escapedDir := shellEscape(dir)
+				script.WriteString("[ -d '" + escapedDir + "' ] && chmod '" + escapedDirMode + "' '" + escapedDir + "' 2>/dev/null || true\n")
+			}
+		}
+
+		// Apply file mode to updated files
+		if ownership.FileMode != "" && len(updatedFiles) > 0 {
+			script.WriteString("# Apply file mode to updated files\n")
+			escapedFileMode := shellEscape(ownership.FileMode)
+			for _, f := range updatedFiles {
+				escapedFile := shellEscape(f)
+				script.WriteString("[ -f '" + escapedFile + "' ] && chmod '" + escapedFileMode + "' '" + escapedFile + "' 2>/dev/null || true\n")
+			}
+		}
+
+		// Apply ownership to updated paths
+		if ownership.User != "" || ownership.Group != "" {
+			script.WriteString("# Apply ownership to updated paths\n")
+			script.WriteString("if [ -n \"${UID_VAL:-}\" ] && [ -n \"${GID_VAL:-}\" ]; then\n")
+			allPaths := updatedFiles
+			for dir := range updatedDirs {
+				allPaths = append(allPaths, dir)
+			}
+			for _, p := range allPaths {
+				escapedPath := shellEscape(p)
+				script.WriteString("  [ -e '" + escapedPath + "' ] && chown \"$UID_VAL:$GID_VAL\" '" + escapedPath + "' 2>/dev/null || true\n")
+			}
+			script.WriteString("elif [ -n \"${UID_VAL:-}\" ]; then\n")
+			for _, p := range allPaths {
+				escapedPath := shellEscape(p)
+				script.WriteString("  [ -e '" + escapedPath + "' ] && chown \"$UID_VAL\" '" + escapedPath + "' 2>/dev/null || true\n")
+			}
+			script.WriteString("elif [ -n \"${GID_VAL:-}\" ]; then\n")
+			for _, p := range allPaths {
+				escapedPath := shellEscape(p)
+				script.WriteString("  [ -e '" + escapedPath + "' ] && chown \":$GID_VAL\" '" + escapedPath + "' 2>/dev/null || true\n")
+			}
+			script.WriteString("fi\n")
+		}
+	} else {
+		// Recursive mode: apply to entire subtree
+		script.WriteString("# Apply to entire subtree\n")
+		escapedRootPath := shellEscape(rootPath)
+
+		// Apply directory mode
+		if ownership.DirMode != "" {
+			escapedDirMode := shellEscape(ownership.DirMode)
+			script.WriteString("find '" + escapedRootPath + "' -type d -exec chmod '" + escapedDirMode + "' {} + 2>/dev/null || true\n")
+		}
+
+		// Apply file mode
+		if ownership.FileMode != "" {
+			escapedFileMode := shellEscape(ownership.FileMode)
+			script.WriteString("find '" + escapedRootPath + "' -type f -exec chmod '" + escapedFileMode + "' {} + 2>/dev/null || true\n")
+		}
+
+		// Apply ownership recursively
+		if ownership.User != "" || ownership.Group != "" {
+			script.WriteString("if [ -n \"${UID_VAL:-}\" ] && [ -n \"${GID_VAL:-}\" ]; then\n")
+			script.WriteString("  chown -R \"$UID_VAL:$GID_VAL\" '" + escapedRootPath + "' 2>/dev/null || true\n")
+			script.WriteString("elif [ -n \"${UID_VAL:-}\" ]; then\n")
+			script.WriteString("  chown -R \"$UID_VAL\" '" + escapedRootPath + "' 2>/dev/null || true\n")
+			script.WriteString("elif [ -n \"${GID_VAL:-}\" ]; then\n")
+			script.WriteString("  chown -R \":$GID_VAL\" '" + escapedRootPath + "' 2>/dev/null || true\n")
+			script.WriteString("fi\n")
+		}
+	}
+
+	script.WriteString("echo 'Ownership applied successfully'\n")
+
+	return script.String(), nil
+}
+
+// isNumeric checks if a string contains only digits.
+func isNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// shellEscape escapes a string for safe use in a shell script within single quotes.
+// It replaces any single quotes with '\” (end quote, escaped quote, start quote).
+func shellEscape(s string) string {
+	// Replace ' with '\''
+	return strings.ReplaceAll(s, "'", "'\\''")
 }

--- a/internal/planner/interfaces.go
+++ b/internal/planner/interfaces.go
@@ -20,6 +20,7 @@ type DockerClient interface {
 	WriteFileToVolume(ctx context.Context, volumeName, targetPath, relFile, content string) error
 	ExtractTarToVolume(ctx context.Context, volumeName, targetPath string, tarReader io.Reader) error
 	RemovePathsFromVolume(ctx context.Context, volumeName, targetPath string, relPaths []string) error
+	RunVolumeScript(ctx context.Context, volumeName, targetPath, script string, env []string) (dockercli.VolumeScriptResult, error)
 
 	// Network operations
 	ListNetworks(ctx context.Context) ([]string, error)

--- a/internal/planner/mock_docker_test.go
+++ b/internal/planner/mock_docker_test.go
@@ -96,6 +96,11 @@ func (m *mockDockerClient) ReadFileFromVolume(ctx context.Context, volumeName, t
 	return content, nil
 }
 
+func (m *mockDockerClient) RunVolumeScript(ctx context.Context, volumeName, targetPath, script string, env []string) (dockercli.VolumeScriptResult, error) {
+	// Mock implementation - just return success
+	return dockercli.VolumeScriptResult{Stdout: "Ownership applied successfully\n"}, nil
+}
+
 func (m *mockDockerClient) WriteFileToVolume(ctx context.Context, volumeName, targetPath, relFile, content string) error {
 	if m.writtenFiles == nil {
 		m.writtenFiles = make(map[string]string)

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -1,6 +1,9 @@
 package util
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
 func SplitNonEmptyLines(s string) []string {
 	var out []string
@@ -18,4 +21,16 @@ func Truncate(s string, max int) string {
 		return s
 	}
 	return s[:max] + "..."
+}
+
+// DirPath returns the directory portion of a path (similar to filepath.Dir but handles slash-separated paths).
+func DirPath(p string) string {
+	if p == "" || p == "." || p == "/" {
+		return ""
+	}
+	dir := filepath.Dir(p)
+	if dir == "." {
+		return ""
+	}
+	return dir
 }

--- a/test/e2e/fileset_ownership_test.go
+++ b/test/e2e/fileset_ownership_test.go
@@ -1,0 +1,292 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gcstr/dockform/internal/dockercli"
+)
+
+func TestFilesetOwnership_NumericIDs(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not found in PATH")
+	}
+	if out := safeOutput(exec.Command("docker", "context", "inspect", "default")); strings.TrimSpace(out) == "" {
+		t.Skip("docker context 'default' not available; skipping e2e")
+	}
+	prevCtx := os.Getenv("DOCKER_CONTEXT")
+	_ = os.Setenv("DOCKER_CONTEXT", "default")
+	t.Cleanup(func() { _ = os.Setenv("DOCKER_CONTEXT", prevCtx) })
+
+	runID := uniqueID()
+	identifier := runID
+	ensureNetworkCreatableOrSkip(t, identifier)
+
+	projectDir := t.TempDir()
+	bin := buildDockform(t)
+
+	t.Cleanup(func() {
+		cleanupByLabel(t, identifier)
+	})
+
+	// Create compose file with a simple service
+	if err := os.WriteFile(filepath.Join(projectDir, "docker-compose.yaml"), []byte(fmt.Sprintf(`
+services:
+  app:
+    image: alpine:3.22
+    command: sleep 1
+    labels:
+      io.dockform.identifier: %s
+    volumes:
+      - data:/data
+
+volumes:
+  data:
+    external: true
+    name: "df_e2e_%s_data"
+`, identifier, runID)), 0644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+
+	// Create source files
+	configDir := filepath.Join(projectDir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "app.conf"), []byte("test=value\n"), 0644); err != nil {
+		t.Fatalf("write app.conf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "secret.conf"), []byte("secret=data\n"), 0644); err != nil {
+		t.Fatalf("write secret.conf: %v", err)
+	}
+
+	// Create manifest with ownership settings using numeric IDs
+	manifest := fmt.Sprintf(`
+docker:
+  identifier: %s
+  context: default
+
+applications:
+  app:
+    root: .
+    files:
+      - docker-compose.yaml
+    project:
+      name: df_e2e_%s
+
+filesets:
+  config:
+    source: ./config
+    target_volume: df_e2e_%s_data
+    target_path: /data
+    ownership:
+      user: "1000"
+      group: "1000"
+      file_mode: "0640"
+      dir_mode: "0750"
+`, identifier, runID, runID)
+
+	manifestPath := filepath.Join(projectDir, "dockform.yaml")
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	env := os.Environ()
+
+	// Apply the manifest
+	applyOut := runCmdWithStdin(t, projectDir, env, bin, "yes\n", "apply", "-c", manifestPath)
+	t.Logf("Apply output:\n%s", applyOut)
+
+	// Verify ownership and permissions inside the volume
+	volumeName := fmt.Sprintf("df_e2e_%s_data", runID)
+	out := runDocker(t, "run", "--rm", "-v", volumeName+":/data", "alpine:3.22", "sh", "-c",
+		"stat -c '%u:%g %a %n' /data /data/app.conf /data/secret.conf 2>&1 || ls -la /data")
+
+	t.Logf("Stat output:\n%s", out)
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 lines of output, got %d: %v", len(lines), lines)
+	}
+
+	// Check directory: /data should be 1000:1000 750
+	if !strings.Contains(lines[0], "1000:1000") {
+		t.Errorf("directory ownership incorrect: %s (expected 1000:1000)", lines[0])
+	}
+	if !strings.Contains(lines[0], "750") {
+		t.Errorf("directory mode incorrect: %s (expected 750)", lines[0])
+	}
+
+	// Check files: should be 1000:1000 640
+	for i := 1; i <= 2; i++ {
+		if !strings.Contains(lines[i], "1000:1000") {
+			t.Errorf("file ownership incorrect: %s (expected 1000:1000)", lines[i])
+		}
+		if !strings.Contains(lines[i], "640") {
+			t.Errorf("file mode incorrect: %s (expected 640)", lines[i])
+		}
+	}
+}
+
+func TestFilesetOwnership_PreserveExisting(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not found in PATH")
+	}
+	if out := safeOutput(exec.Command("docker", "context", "inspect", "default")); strings.TrimSpace(out) == "" {
+		t.Skip("docker context 'default' not available; skipping e2e")
+	}
+	prevCtx := os.Getenv("DOCKER_CONTEXT")
+	_ = os.Setenv("DOCKER_CONTEXT", "default")
+	t.Cleanup(func() { _ = os.Setenv("DOCKER_CONTEXT", prevCtx) })
+
+	ctx := context.Background()
+	runID := uniqueID()
+	identifier := runID
+	ensureNetworkCreatableOrSkip(t, identifier)
+
+	projectDir := t.TempDir()
+	bin := buildDockform(t)
+
+	t.Cleanup(func() {
+		cleanupByLabel(t, identifier)
+	})
+
+	// Create compose file
+	if err := os.WriteFile(filepath.Join(projectDir, "docker-compose.yaml"), []byte(fmt.Sprintf(`
+services:
+  app:
+    image: alpine:3.22
+    command: sleep 1
+    labels:
+      io.dockform.identifier: %s
+    volumes:
+      - data:/data
+
+volumes:
+  data:
+    external: true
+    name: "df_e2e_%s_data"
+`, identifier, runID)), 0644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+
+	// Create initial source file
+	configDir := filepath.Join(projectDir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "file1.txt"), []byte("content1\n"), 0644); err != nil {
+		t.Fatalf("write file1: %v", err)
+	}
+
+	// Create manifest without preserve_existing (will apply to all)
+	manifest := fmt.Sprintf(`
+docker:
+  identifier: %s
+  context: default
+
+applications:
+  app:
+    root: .
+    files:
+      - docker-compose.yaml
+    project:
+      name: df_e2e_%s
+
+filesets:
+  config:
+    source: ./config
+    target_volume: df_e2e_%s_data
+    target_path: /data
+    ownership:
+      user: "2000"
+      group: "2000"
+      file_mode: "0600"
+`, identifier, runID, runID)
+
+	manifestPath := filepath.Join(projectDir, "dockform.yaml")
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	env := os.Environ()
+
+	// First apply
+	_ = runCmdWithStdin(t, projectDir, env, bin, "yes\n", "apply", "-c", manifestPath)
+
+	volumeName := fmt.Sprintf("df_e2e_%s_data", runID)
+
+	// Verify initial ownership using dockercli
+	docker := dockercli.New("default")
+	result, err := docker.RunVolumeScript(ctx, volumeName, "/data", "stat -c '%u:%g' /data/file1.txt", nil)
+	if err != nil {
+		t.Fatalf("failed to check initial ownership: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "2000:2000") {
+		t.Fatalf("initial ownership incorrect: %s (expected 2000:2000)", result.Stdout)
+	}
+
+	// Add a new file and enable preserve_existing
+	if err := os.WriteFile(filepath.Join(configDir, "file2.txt"), []byte("content2\n"), 0644); err != nil {
+		t.Fatalf("write file2: %v", err)
+	}
+
+	// Update manifest with preserve_existing and different ownership
+	manifest = fmt.Sprintf(`
+docker:
+  identifier: %s
+  context: default
+
+applications:
+  app:
+    root: .
+    files:
+      - docker-compose.yaml
+    project:
+      name: df_e2e_%s
+
+filesets:
+  config:
+    source: ./config
+    target_volume: df_e2e_%s_data
+    target_path: /data
+    ownership:
+      user: "3000"
+      group: "3000"
+      file_mode: "0644"
+      preserve_existing: true
+`, identifier, runID, runID)
+
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0644); err != nil {
+		t.Fatalf("write updated manifest: %v", err)
+	}
+
+	// Second apply
+	_ = runCmdWithStdin(t, projectDir, env, bin, "yes\n", "apply", "-c", manifestPath)
+
+	// Verify: file1 should still be 2000:2000, file2 should be 3000:3000
+	result, err = docker.RunVolumeScript(ctx, volumeName, "/data", "stat -c '%u:%g %n' /data/file1.txt /data/file2.txt", nil)
+	if err != nil {
+		t.Fatalf("failed to check final ownership: %v\nstderr: %s", err, result.Stderr)
+	}
+
+	lines := strings.Split(strings.TrimSpace(result.Stdout), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
+	}
+
+	// file1 should keep old ownership (preserve_existing=true doesn't re-apply to unchanged files)
+	if !strings.Contains(lines[0], "2000:2000") {
+		t.Errorf("file1 ownership changed unexpectedly: %s (expected 2000:2000)", lines[0])
+	}
+
+	// file2 should have new ownership (it's a new file)
+	if !strings.Contains(lines[1], "3000:3000") {
+		t.Errorf("file2 ownership incorrect: %s (expected 3000:3000)", lines[1])
+	}
+}


### PR DESCRIPTION
Adds the ability to configure ownership and permissions for filesets.

This change introduces:
- A new `Ownership` struct in the manifest to define user, group, and mode settings.
- Validation and normalization of ownership settings.
- The ability to apply ownership settings to fileset files after they are synced, including preserve existing files.
- Helper functions for running commands within a Docker volume.

The changes include:
- Adds E2E tests to validate ownership and permission settings.
- Adds `DirPath` function to extract the directory from a file path.
- Implements fileset ownership and permissions application logic.
- Adds `RunVolumeScript` and `RunInHelperImage` functions to `dockercli` for executing commands within a Docker volume.
- Adds `RunDetailed` function to `dockercli` to capture `stdout` and `stderr` from executed commands.
- Improves the helper image check in the doctor command to verify the presence of required binaries.