### PR TITLE
Fix: sops paths and network destroy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,11 @@ example/website/assets/
 .gocache/
 
 cover.html
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+
+# Git worktrees
+.worktrees/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -102,5 +102,3 @@ brews:
 release:
   draft: false
   prerelease: auto
-  # "Latest" for stable tags, skipped for pre-releases
-  make_latest: auto

--- a/internal/dockercli/compose.go
+++ b/internal/dockercli/compose.go
@@ -246,6 +246,27 @@ func (c *Client) buildLabeledProjectTemp(ctx context.Context, workingDir string,
 		services[name] = service
 	}
 	doc["services"] = services
+
+	// Inject identifier label into compose-defined networks so they are
+	// discoverable by ListNetworks (which filters by this label) during destroy.
+	networks, _ := doc["networks"].(map[string]any)
+	if networks != nil {
+		for name, val := range networks {
+			network, _ := val.(map[string]any)
+			if network == nil {
+				network = map[string]any{}
+			}
+			labels, _ := network["labels"].(map[string]any)
+			if labels == nil {
+				labels = map[string]any{}
+			}
+			labels["io.dockform.identifier"] = identifier
+			network["labels"] = labels
+			networks[name] = network
+		}
+		doc["networks"] = networks
+	}
+
 	b, err := yaml.Marshal(doc)
 	if err != nil {
 		return "", apperr.Wrap("dockercli.buildLabeledProjectTemp", apperr.Internal, err, "marshal labeled yaml")

--- a/internal/dockercli/compose_test.go
+++ b/internal/dockercli/compose_test.go
@@ -238,6 +238,43 @@ func TestBuildLabeledProjectTemp_AddsIdentifierLabel(t *testing.T) {
 	}
 }
 
+func TestBuildLabeledProjectTemp_AddsIdentifierLabelToNetworks(t *testing.T) {
+	yam := `services:
+  whoami:
+    image: traefik/whoami
+    networks:
+      - whoami
+networks:
+  whoami:
+    name: whoami
+`
+	f := &fakeExec{outConfigYAML: yam}
+	c := &Client{exec: f}
+	path, err := c.buildLabeledProjectTemp(context.Background(), t.TempDir(), []string{"compose.yml"}, nil, nil, "proj", "demo", nil)
+	if err != nil {
+		t.Fatalf("build labeled: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read tmp: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	nets, _ := doc["networks"].(map[string]any)
+	if len(nets) == 0 {
+		t.Fatal("expected networks section in labeled overlay")
+	}
+	for name, v := range nets {
+		net, _ := v.(map[string]any)
+		labels, _ := net["labels"].(map[string]any)
+		if labels == nil || labels["io.dockform.identifier"] != "demo" {
+			t.Fatalf("network %s missing identifier label: %#v", name, labels)
+		}
+	}
+}
+
 func TestComposeUp_UsesOverlayWhenIdentifier(t *testing.T) {
 	// Ensure that when identifier is set, the compose args include only one -f <tempfile>
 	yam := "services:\n  web:\n    image: nginx\n"

--- a/internal/manifest/bind_mount_validator.go
+++ b/internal/manifest/bind_mount_validator.go
@@ -50,26 +50,26 @@ func validateBindMountsInComposeFile(stackKey string, stack Stack) error {
 	context, stackName, _ := ParseStackKey(stackKey)
 
 	var msg strings.Builder
-	msg.WriteString(fmt.Sprintf("stack %s contains bind mounts with relative paths which will not work correctly with remote Docker contexts.\n\n", stackKey))
+	fmt.Fprintf(&msg, "stack %s contains bind mounts with relative paths which will not work correctly with remote Docker contexts.\n\n", stackKey)
 	msg.WriteString("Bind mounts found:\n")
 	for _, bm := range allBindMounts {
-		msg.WriteString(fmt.Sprintf("  - %s\n", bm))
+		fmt.Fprintf(&msg, "  - %s\n", bm)
 	}
 	msg.WriteString("\nBind mounts reference paths on the Docker daemon's filesystem, not your local machine.\n")
 	msg.WriteString("When using remote Docker contexts, these paths would be resolved on the remote server.\n\n")
 	msg.WriteString("Solution: Use Dockform filesets for syncing local files to remote volumes.\n\n")
 	msg.WriteString("Migration steps:\n")
-	msg.WriteString(fmt.Sprintf("  1. Create a 'volumes/' directory in your stack: %s/%s/volumes/\n", context, stackName))
+	fmt.Fprintf(&msg, "  1. Create a 'volumes/' directory in your stack: %s/%s/volumes/\n", context, stackName)
 	msg.WriteString("  2. Move your bind mount directories into volumes/\n")
-	msg.WriteString(fmt.Sprintf("     Example: ./config → %s/%s/volumes/config/\n", context, stackName))
+	fmt.Fprintf(&msg, "     Example: ./config → %s/%s/volumes/config/\n", context, stackName)
 	msg.WriteString("  3. Change compose volumes to use named volumes:\n")
 	msg.WriteString("     - Old: ./config:/app/config\n")
-	msg.WriteString(fmt.Sprintf("     - New: %s_config:/app/config\n", stackName))
+	fmt.Fprintf(&msg, "     - New: %s_config:/app/config\n", stackName)
 	msg.WriteString("  4. Declare the volume in dockform.yaml:\n")
 	msg.WriteString("     contexts:\n")
-	msg.WriteString(fmt.Sprintf("       %s:\n", context))
+	fmt.Fprintf(&msg, "       %s:\n", context)
 	msg.WriteString("         volumes:\n")
-	msg.WriteString(fmt.Sprintf("           %s_config: {}\n\n", stackName))
+	fmt.Fprintf(&msg, "           %s_config: {}\n\n", stackName)
 	msg.WriteString("Dockform will auto-discover the fileset and sync files correctly to the remote server.\n")
 	msg.WriteString("See: https://github.com/gcstr/dockform#filesets for more information.")
 

--- a/internal/manifest/validation.go
+++ b/internal/manifest/validation.go
@@ -167,6 +167,18 @@ func (c *Config) normalizeAndValidate(baseDir string) error {
 			stack.SopsSecrets = append(stack.SopsSecrets, stack.Secrets.Sops...)
 		}
 
+		// Resolve relative SOPS secret paths to absolute paths.
+		// Prefer stack.Root as the base; fall back to the manifest's baseDir.
+		for i, sp := range stack.SopsSecrets {
+			if sp != "" && !filepath.IsAbs(sp) {
+				base := baseDir
+				if stack.Root != "" {
+					base = stack.Root
+				}
+				stack.SopsSecrets[i] = filepath.Clean(filepath.Join(base, sp))
+			}
+		}
+
 		// Validate SOPS secrets have .env extension
 		for _, sp := range stack.SopsSecrets {
 			if !strings.HasSuffix(strings.ToLower(sp), ".env") {

--- a/internal/manifest/validation_test.go
+++ b/internal/manifest/validation_test.go
@@ -155,6 +155,89 @@ func TestNormalize_SopsSecretsValidation(t *testing.T) {
 	}
 }
 
+func TestNormalize_SopsSecrets_RelativePathsResolved(t *testing.T) {
+	base := t.TempDir()
+
+	t.Run("relative path resolved against stack root", func(t *testing.T) {
+		stackRoot := filepath.Join(base, "app")
+		cfg := Config{
+			Identifier: "test",
+			Contexts:   map[string]ContextConfig{"default": {}},
+			Stacks: map[string]Stack{
+				"default/web": {
+					Root: stackRoot,
+					Secrets: &Secrets{
+						Sops: []string{"./secrets/secrets.env"},
+					},
+				},
+			},
+		}
+		if err := cfg.normalizeAndValidate(base); err != nil {
+			t.Fatalf("normalizeAndValidate: %v", err)
+		}
+		stack := cfg.Stacks["default/web"]
+		if len(stack.SopsSecrets) != 1 {
+			t.Fatalf("expected 1 SopsSecret, got %d: %v", len(stack.SopsSecrets), stack.SopsSecrets)
+		}
+		got := stack.SopsSecrets[0]
+		want := filepath.Join(stackRoot, "secrets/secrets.env")
+		if got != want {
+			t.Fatalf("SopsSecrets[0]: want %q, got %q", want, got)
+		}
+	})
+
+	t.Run("relative path resolved against baseDir when stack root is empty", func(t *testing.T) {
+		cfg := Config{
+			Identifier: "test",
+			Contexts:   map[string]ContextConfig{"default": {}},
+			Stacks: map[string]Stack{
+				"default/web": {
+					Secrets: &Secrets{
+						Sops: []string{"./secrets/secrets.env"},
+					},
+				},
+			},
+		}
+		if err := cfg.normalizeAndValidate(base); err != nil {
+			t.Fatalf("normalizeAndValidate: %v", err)
+		}
+		stack := cfg.Stacks["default/web"]
+		if len(stack.SopsSecrets) != 1 {
+			t.Fatalf("expected 1 SopsSecret, got %d: %v", len(stack.SopsSecrets), stack.SopsSecrets)
+		}
+		got := stack.SopsSecrets[0]
+		want := filepath.Join(base, "secrets/secrets.env")
+		if got != want {
+			t.Fatalf("SopsSecrets[0]: want %q, got %q", want, got)
+		}
+	})
+
+	t.Run("absolute path left unchanged", func(t *testing.T) {
+		abs := "/absolute/path/secrets.env"
+		cfg := Config{
+			Identifier: "test",
+			Contexts:   map[string]ContextConfig{"default": {}},
+			Stacks: map[string]Stack{
+				"default/web": {
+					Secrets: &Secrets{
+						Sops: []string{abs},
+					},
+				},
+			},
+		}
+		if err := cfg.normalizeAndValidate(base); err != nil {
+			t.Fatalf("normalizeAndValidate: %v", err)
+		}
+		stack := cfg.Stacks["default/web"]
+		if len(stack.SopsSecrets) != 1 {
+			t.Fatalf("expected 1 SopsSecret, got %d", len(stack.SopsSecrets))
+		}
+		if got := stack.SopsSecrets[0]; got != abs {
+			t.Fatalf("SopsSecrets[0]: want %q, got %q", abs, got)
+		}
+	})
+}
+
 func TestFindDefaultComposeFile(t *testing.T) {
 	// Test selection order: compose.yaml > compose.yml > docker-compose.yaml > docker-compose.yml
 	t.Run("prefer_compose_yaml_over_others", func(t *testing.T) {


### PR DESCRIPTION
Fix SOPS relative paths and Network destroy

When a stack's secrets.sops contained a relative path like `./secrets/foo.env`, it was stored as-is in SopsSecrets. The validator and secrets decryption code both tried to resolve it against stack.Root, but that's empty for explicitly defined stacks so os.Stat failed. Fix: resolve relative paths to absolute during normalizeAndValidate(), using stack.Root if set, baseDir otherwise.

Networks defined in compose files (not in the dockform manifest) were created without the label, and `ListNetworks` (which filters by that label) never found them during destroy. 

closes: #44 and #43 