### PR TITLE
images check upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	filippo.io/age v1.2.1
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/alecthomas/chroma/v2 v2.13.0
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/charmbracelet/bubbles v0.20.0
@@ -22,7 +23,6 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3I
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 filippo.io/age v1.2.1 h1:X0TZjehAZylOIj4DubWYU1vWQxv9bJpo+Uu2/LGhi1o=
 filippo.io/age v1.2.1/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=
 github.com/alecthomas/assert/v2 v2.6.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.13.0 h1:VP72+99Fb2zEcYM0MeaWJmV+xQvz5v5cxRHd+ooU1lI=

--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -75,11 +75,9 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 	localDigestFn := makeLocalDigestFunc(cfg, factory)
 
 	// Run the check.
-	sequential, _ := cmd.Flags().GetBool("sequential")
-
 	var results []images.ImageStatus
 	err = common.SpinnerOperation(pr, "Checking images...", func() error {
-		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn, sequential)
+		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn)
 		return err
 	})
 	if err != nil {

--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -311,7 +311,21 @@ func statusText(r images.ImageStatus) string {
 		return ui.YellowText("newer: " + strings.Join(r.NewerTags, ", "))
 	}
 	if r.DigestStale {
+		local := shortDigest(r.LocalDigest)
+		remote := shortDigest(r.RemoteDigest)
+		if local != "" && remote != "" {
+			return ui.YellowText("updated upstream (" + local + " → " + remote + ")")
+		}
 		return ui.YellowText("updated upstream")
 	}
 	return ui.GreenText("up to date")
+}
+
+// shortDigest returns the first 12 hex characters after "sha256:" for display.
+func shortDigest(d string) string {
+	const prefix = "sha256:"
+	if after, ok := strings.CutPrefix(d, prefix); ok && len(after) >= 12 {
+		return after[:12]
+	}
+	return ""
 }

--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -252,17 +252,17 @@ func renderTerminal(pr ui.Printer, results []images.ImageStatus) {
 
 		for _, r := range g.results {
 			if r.Error != "" {
-				pr.Plain("  %-30s %s %s", r.Image+":"+r.CurrentTag, ui.YellowText("!"), r.Error)
+				pr.Plain("  %-40s %s %s", r.Image, ui.YellowText("⚠"), r.Error)
 				continue
 			}
 
 			if len(r.NewerTags) > 0 {
 				tags := strings.Join(r.NewerTags, ", ")
-				pr.Plain("  %-30s %s newer versions: %s", r.Image+":"+r.CurrentTag, ui.YellowText("!"), tags)
+				pr.Plain("  %-40s %s newer versions: %s", r.Image, ui.YellowText("⚠"), tags)
 			} else if r.DigestStale {
-				pr.Plain("  %-30s %s updated upstream", r.Image+":"+r.CurrentTag, ui.YellowText("!"))
+				pr.Plain("  %-40s %s updated upstream", r.Image, ui.YellowText("⚠"))
 			} else {
-				pr.Plain("  %-30s %s up to date", r.Image+":"+r.CurrentTag, ui.GreenText("ok"))
+				pr.Plain("  %-40s %s up to date", r.Image, ui.GreenText("✓"))
 			}
 		}
 	}

--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -1,0 +1,269 @@
+package imagescmd
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/gcstr/dockform/internal/apperr"
+	"github.com/gcstr/dockform/internal/cli/common"
+	"github.com/gcstr/dockform/internal/dockercli"
+	"github.com/gcstr/dockform/internal/images"
+	"github.com/gcstr/dockform/internal/manifest"
+	"github.com/gcstr/dockform/internal/registry"
+	"github.com/gcstr/dockform/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func newCheckCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Check image freshness across compose stacks",
+		RunE:  runCheck,
+	}
+
+	cmd.Flags().Bool("json", false, "Output results as JSON")
+	cmd.Flags().Bool("sequential", false, "Disable parallel checks (reserved for future use)")
+
+	common.AddTargetFlags(cmd)
+
+	return cmd
+}
+
+func runCheck(cmd *cobra.Command, _ []string) error {
+	pr := ui.StdPrinter{Out: cmd.OutOrStdout(), Err: cmd.ErrOrStderr()}
+
+	// Load configuration with warnings.
+	cfg, err := common.LoadConfigWithWarnings(cmd, pr)
+	if err != nil {
+		return err
+	}
+
+	// Apply target filtering if flags are provided.
+	opts := common.ReadTargetOptions(cmd)
+	if !opts.IsEmpty() {
+		cfg, err = common.ResolveTargets(cfg, opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	common.DisplayDaemonInfo(pr, cfg)
+
+	// Create client factory for multi-context support.
+	factory := common.CreateClientFactory()
+
+	// Create registry client.
+	reg := registry.NewOCIClient(nil)
+
+	// Build check inputs from all stacks.
+	inputs, err := buildCheckInputs(cmd.Context(), cfg, factory)
+	if err != nil {
+		return err
+	}
+
+	if len(inputs) == 0 {
+		pr.Plain("\nNo stacks with images found.")
+		return nil
+	}
+
+	// Build a local digest function using the factory.
+	localDigestFn := makeLocalDigestFunc(cfg, factory)
+
+	// Run the check.
+	var results []images.ImageStatus
+	err = common.SpinnerOperation(pr, "Checking images...", func() error {
+		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	// Render output.
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+	if jsonFlag {
+		return renderJSON(cmd, results)
+	}
+
+	renderTerminal(pr, results)
+	return nil
+}
+
+// buildCheckInputs iterates over all stacks and builds CheckInput entries
+// by calling ComposeConfigFull to discover service images.
+func buildCheckInputs(ctx context.Context, cfg *manifest.Config, factory *dockercli.DefaultClientFactory) ([]images.CheckInput, error) {
+	allStacks := cfg.GetAllStacks()
+
+	// Sort stack keys for deterministic output.
+	stackKeys := make([]string, 0, len(allStacks))
+	for k := range allStacks {
+		stackKeys = append(stackKeys, k)
+	}
+	sort.Strings(stackKeys)
+
+	var inputs []images.CheckInput
+
+	for _, stackKey := range stackKeys {
+		stack := allStacks[stackKey]
+
+		ctxName, _, err := manifest.ParseStackKey(stackKey)
+		if err != nil {
+			return nil, err
+		}
+
+		// Get a docker client for this stack's context.
+		client := factory.GetClientForContext(ctxName, cfg)
+
+		// Get the full compose config to extract service images.
+		doc, err := client.ComposeConfigFull(ctx, stack.RootAbs, stack.Files, stack.Profiles, stack.EnvFile, stack.EnvInline)
+		if err != nil {
+			return nil, apperr.Wrap("imagescmd.buildCheckInputs", apperr.External, err, "failed to get compose config for stack %s", stackKey)
+		}
+
+		if len(doc.Services) == 0 {
+			continue
+		}
+
+		services := make(map[string]string, len(doc.Services))
+		for svcName, svc := range doc.Services {
+			if svc.Image != "" {
+				services[svcName] = svc.Image
+			}
+		}
+
+		if len(services) == 0 {
+			continue
+		}
+
+		input := images.CheckInput{
+			StackKey: stackKey,
+			Services: services,
+		}
+
+		if stack.Images != nil {
+			input.TagPattern = stack.Images.TagPattern
+		}
+
+		inputs = append(inputs, input)
+	}
+
+	return inputs, nil
+}
+
+// makeLocalDigestFunc creates a LocalDigestFunc that uses docker image inspect
+// to retrieve the local repo digest for an image. This is best-effort: if the
+// image is not pulled or has no repo digests, it returns an empty string (which
+// will cause the image to appear stale).
+func makeLocalDigestFunc(cfg *manifest.Config, factory *dockercli.DefaultClientFactory) images.LocalDigestFunc {
+	// Use the first context's client for local digest lookups.
+	// In a remote-context world this inspects images on the remote host.
+	firstCtx := cfg.GetFirstContext()
+	client := factory.GetClientForContext(firstCtx, cfg)
+
+	return func(ctx context.Context, imageRef string) (string, error) {
+		out, err := client.ImageInspectRepoDigests(ctx, imageRef)
+		if err != nil {
+			// Image not pulled or inspect failed — treat as stale.
+			return "", nil //nolint:nilerr // best-effort
+		}
+
+		if len(out) == 0 {
+			return "", nil
+		}
+
+		// Return the first repo digest. The format is "registry/name@sha256:abc...".
+		// We return just the digest portion for comparison with the remote digest.
+		for _, rd := range out {
+			if idx := strings.LastIndex(rd, "@"); idx >= 0 {
+				return rd[idx+1:], nil
+			}
+		}
+
+		return "", nil
+	}
+}
+
+// jsonResult is the JSON output format for a single image check result.
+type jsonResult struct {
+	Stack         string   `json:"stack"`
+	Service       string   `json:"service"`
+	Image         string   `json:"image"`
+	CurrentTag    string   `json:"current_tag"`
+	DigestChanged bool     `json:"digest_changed"`
+	NewerTags     []string `json:"newer_tags,omitempty"`
+	Error         string   `json:"error,omitempty"`
+}
+
+func renderJSON(cmd *cobra.Command, results []images.ImageStatus) error {
+	out := make([]jsonResult, 0, len(results))
+	for _, r := range results {
+		out = append(out, jsonResult{
+			Stack:         r.Stack,
+			Service:       r.Service,
+			Image:         r.Image,
+			CurrentTag:    r.CurrentTag,
+			DigestChanged: r.DigestStale,
+			NewerTags:     r.NewerTags,
+			Error:         r.Error,
+		})
+	}
+
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		return apperr.Wrap("imagescmd.renderJSON", apperr.Internal, err, "failed to encode JSON output")
+	}
+	return nil
+}
+
+func renderTerminal(pr ui.Printer, results []images.ImageStatus) {
+	if len(results) == 0 {
+		pr.Plain("\nNo images found.")
+		return
+	}
+
+	// Group results by stack for display.
+	type stackGroup struct {
+		key     string
+		results []images.ImageStatus
+	}
+
+	seen := make(map[string]int)
+	var groups []stackGroup
+
+	for _, r := range results {
+		idx, ok := seen[r.Stack]
+		if !ok {
+			idx = len(groups)
+			seen[r.Stack] = idx
+			groups = append(groups, stackGroup{key: r.Stack})
+		}
+		groups[idx].results = append(groups[idx].results, r)
+	}
+
+	for i, g := range groups {
+		if i > 0 {
+			pr.Plain("")
+		}
+		pr.Plain("Stack: %s", g.key)
+		pr.Plain("")
+
+		for _, r := range g.results {
+			if r.Error != "" {
+				pr.Plain("  %-30s %s %s", r.Image+":"+r.CurrentTag, ui.YellowText("!"), r.Error)
+				continue
+			}
+
+			if len(r.NewerTags) > 0 {
+				tags := strings.Join(r.NewerTags, ", ")
+				pr.Plain("  %-30s %s newer versions: %s", r.Image+":"+r.CurrentTag, ui.YellowText("!"), tags)
+			} else if r.DigestStale {
+				pr.Plain("  %-30s %s updated upstream", r.Image+":"+r.CurrentTag, ui.YellowText("!"))
+			} else {
+				pr.Plain("  %-30s %s up to date", r.Image+":"+r.CurrentTag, ui.GreenText("ok"))
+			}
+		}
+	}
+}

--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -75,9 +75,11 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 	localDigestFn := makeLocalDigestFunc(cfg, factory)
 
 	// Run the check.
+	sequential, _ := cmd.Flags().GetBool("sequential")
+
 	var results []images.ImageStatus
 	err = common.SpinnerOperation(pr, "Checking images...", func() error {
-		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn)
+		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn, sequential)
 		return err
 	})
 	if err != nil {

--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -311,21 +311,7 @@ func statusText(r images.ImageStatus) string {
 		return ui.YellowText("newer: " + strings.Join(r.NewerTags, ", "))
 	}
 	if r.DigestStale {
-		local := shortDigest(r.LocalDigest)
-		remote := shortDigest(r.RemoteDigest)
-		if local != "" && remote != "" {
-			return ui.YellowText("updated upstream (" + local + " → " + remote + ")")
-		}
 		return ui.YellowText("updated upstream")
 	}
 	return ui.GreenText("up to date")
-}
-
-// shortDigest returns the first 12 hex characters after "sha256:" for display.
-func shortDigest(d string) string {
-	const prefix = "sha256:"
-	if after, ok := strings.CutPrefix(d, prefix); ok && len(after) >= 12 {
-		return after[:12]
-	}
-	return ""
 }

--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -3,6 +3,7 @@ package imagescmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -25,6 +26,7 @@ func newCheckCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Bool("json", false, "Output results as JSON")
+	cmd.Flags().Bool("all", false, "Show all images, including those that are up to date")
 	cmd.Flags().Bool("sequential", false, "Disable parallel checks (reserved for future use)")
 
 	common.AddTargetFlags(cmd)
@@ -88,7 +90,8 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 		return renderJSON(cmd, results)
 	}
 
-	renderTerminal(pr, results)
+	showAll, _ := cmd.Flags().GetBool("all")
+	renderTerminal(pr, results, showAll)
 	return nil
 }
 
@@ -219,52 +222,96 @@ func renderJSON(cmd *cobra.Command, results []images.ImageStatus) error {
 	return nil
 }
 
-func renderTerminal(pr ui.Printer, results []images.ImageStatus) {
+func renderTerminal(pr ui.Printer, results []images.ImageStatus, showAll bool) {
 	if len(results) == 0 {
 		pr.Plain("\nNo images found.")
 		return
 	}
 
-	// Group results by stack for display.
-	type stackGroup struct {
-		key     string
-		results []images.ImageStatus
-	}
-
-	seen := make(map[string]int)
-	var groups []stackGroup
-
+	// Split into attention-needed and ok.
+	var attention, ok []images.ImageStatus
 	for _, r := range results {
-		idx, ok := seen[r.Stack]
-		if !ok {
-			idx = len(groups)
-			seen[r.Stack] = idx
-			groups = append(groups, stackGroup{key: r.Stack})
+		if r.Error != "" || r.DigestStale || len(r.NewerTags) > 0 {
+			attention = append(attention, r)
+		} else {
+			ok = append(ok, r)
 		}
-		groups[idx].results = append(groups[idx].results, r)
 	}
 
-	boldStyle := lipgloss.NewStyle().Bold(true)
-	for i, g := range groups {
-		if i > 0 {
+	dimStyle := lipgloss.NewStyle().Faint(true)
+	headerStyle := lipgloss.NewStyle().Faint(true).Bold(true)
+
+	renderTable := func(rows []images.ImageStatus) {
+		// Compute column widths dynamically.
+		wStack, wImage, wTag := len("STACK"), len("IMAGE"), len("TAG")
+		for _, r := range rows {
+			stack, image, tag := r.Stack, imageNameWithoutTag(r.Image), r.CurrentTag
+			if len(stack) > wStack {
+				wStack = len(stack)
+			}
+			if len(image) > wImage {
+				wImage = len(image)
+			}
+			if len(tag) > wTag {
+				wTag = len(tag)
+			}
+		}
+		// Column header.
+		pr.Plain("  %s  %s  %s  %s",
+			headerStyle.Render(fmt.Sprintf("%-*s", wStack, "STACK")),
+			headerStyle.Render(fmt.Sprintf("%-*s", wImage, "IMAGE")),
+			headerStyle.Render(fmt.Sprintf("%-*s", wTag, "TAG")),
+			headerStyle.Render("STATUS"),
+		)
+		for _, r := range rows {
+			stack := fmt.Sprintf("%-*s", wStack, r.Stack)
+			image := fmt.Sprintf("%-*s", wImage, imageNameWithoutTag(r.Image))
+			tag := fmt.Sprintf("%-*s", wTag, r.CurrentTag)
+			status := statusText(r)
+			pr.Plain("  %s  %s  %s  %s", stack, image, tag, status)
+		}
+	}
+
+	if len(attention) > 0 {
+		pr.Plain("%s  %d image(s) need attention\n", ui.YellowText("⚠"), len(attention))
+		renderTable(attention)
+	}
+
+	if len(ok) > 0 {
+		if len(attention) > 0 {
 			pr.Plain("")
 		}
-		pr.Plain("%s", boldStyle.Render(g.key))
-
-		for _, r := range g.results {
-			if r.Error != "" {
-				pr.Plain("  %-40s %s %s", r.Image, ui.YellowText("⚠"), r.Error)
-				continue
-			}
-
-			if len(r.NewerTags) > 0 {
-				tags := strings.Join(r.NewerTags, ", ")
-				pr.Plain("  %-40s %s newer versions: %s", r.Image, ui.YellowText("⚠"), tags)
-			} else if r.DigestStale {
-				pr.Plain("  %-40s %s updated upstream", r.Image, ui.YellowText("⚠"))
-			} else {
-				pr.Plain("  %-40s %s up to date", r.Image, ui.GreenText("✓"))
-			}
+		if showAll {
+			pr.Plain("%s  %d image(s) up to date\n", ui.GreenText("✓"), len(ok))
+			renderTable(ok)
+		} else {
+			pr.Plain("%s  %d image(s) up to date  %s",
+				ui.GreenText("✓"), len(ok), dimStyle.Render("(--all to show)"))
 		}
 	}
+}
+
+// imageNameWithoutTag strips the tag from an image reference.
+func imageNameWithoutTag(image string) string {
+	// Find last slash to isolate the name:tag part.
+	lastSlash := strings.LastIndex(image, "/")
+	nameTag := image[lastSlash+1:]
+	if idx := strings.LastIndex(nameTag, ":"); idx >= 0 {
+		return image[:lastSlash+1+idx]
+	}
+	return image
+}
+
+// statusText returns the human-readable status for an image result.
+func statusText(r images.ImageStatus) string {
+	if r.Error != "" {
+		return ui.YellowText("! " + r.Error)
+	}
+	if len(r.NewerTags) > 0 {
+		return ui.YellowText("newer: " + strings.Join(r.NewerTags, ", "))
+	}
+	if r.DigestStale {
+		return ui.YellowText("updated upstream")
+	}
+	return ui.GreenText("up to date")
 }

--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/gcstr/dockform/internal/apperr"
 	"github.com/gcstr/dockform/internal/cli/common"
 	"github.com/gcstr/dockform/internal/dockercli"
@@ -243,12 +244,12 @@ func renderTerminal(pr ui.Printer, results []images.ImageStatus) {
 		groups[idx].results = append(groups[idx].results, r)
 	}
 
+	boldStyle := lipgloss.NewStyle().Bold(true)
 	for i, g := range groups {
 		if i > 0 {
 			pr.Plain("")
 		}
-		pr.Plain("Stack: %s", g.key)
-		pr.Plain("")
+		pr.Plain("%s", boldStyle.Render(g.key))
 
 		for _, r := range g.results {
 			if r.Error != "" {

--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -71,13 +71,16 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	// Build a local digest function using the factory.
-	localDigestFn := makeLocalDigestFunc(cfg, factory)
+	// Pre-fetch local digests sequentially before parallel registry checks.
+	// Running exec.Command concurrently (especially over SSH contexts) is unreliable.
+	localDigests := prefetchLocalDigests(cmd.Context(), inputs, makeLocalDigestFunc(cfg, factory))
 
-	// Run the check.
+	// Run the check — registry HTTP calls run in parallel, local digests from cache.
 	var results []images.ImageStatus
 	err = common.SpinnerOperation(pr, "Checking images...", func() error {
-		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn)
+		results, err = images.Check(cmd.Context(), inputs, reg, func(ctx context.Context, imageRef string) (string, error) {
+			return localDigests[imageRef], nil
+		})
 		return err
 	})
 	if err != nil {
@@ -187,6 +190,24 @@ func makeLocalDigestFunc(cfg *manifest.Config, factory *dockercli.DefaultClientF
 
 		return "", nil
 	}
+}
+
+// prefetchLocalDigests calls localDigestFn sequentially for every image ref
+// across all inputs and returns a map of imageRef -> digest. This avoids
+// concurrent exec.Command calls to the Docker daemon which are unreliable
+// over SSH contexts.
+func prefetchLocalDigests(ctx context.Context, inputs []images.CheckInput, fn images.LocalDigestFunc) map[string]string {
+	out := make(map[string]string)
+	for _, input := range inputs {
+		for _, imageRef := range input.Services {
+			if _, seen := out[imageRef]; seen {
+				continue
+			}
+			digest, _ := fn(ctx, imageRef) // best-effort: empty string on failure
+			out[imageRef] = digest
+		}
+	}
+	return out
 }
 
 // jsonResult is the JSON output format for a single image check result.

--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -78,8 +78,8 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 	// Run the check — registry HTTP calls run in parallel, local digests from cache.
 	var results []images.ImageStatus
 	err = common.SpinnerOperation(pr, "Checking images...", func() error {
-		results, err = images.Check(cmd.Context(), inputs, reg, func(ctx context.Context, imageRef string) (string, error) {
-			return localDigests[imageRef], nil
+		results, err = images.Check(cmd.Context(), inputs, reg, func(ctx context.Context, stackKey, imageRef string) (string, error) {
+			return localDigests[stackKey+"|"+imageRef], nil
 		})
 		return err
 	})
@@ -160,16 +160,17 @@ func buildCheckInputs(ctx context.Context, cfg *manifest.Config, factory *docker
 }
 
 // makeLocalDigestFunc creates a LocalDigestFunc that uses docker image inspect
-// to retrieve the local repo digest for an image. This is best-effort: if the
-// image is not pulled or has no repo digests, it returns an empty string (which
-// will cause the image to appear stale).
+// to retrieve the local repo digest for an image on the Docker daemon
+// associated with the image's stack. This is best-effort: if the image is not
+// pulled or has no repo digests, it returns an empty string (which will cause
+// the image to appear stale).
 func makeLocalDigestFunc(cfg *manifest.Config, factory *dockercli.DefaultClientFactory) images.LocalDigestFunc {
-	// Use the first context's client for local digest lookups.
-	// In a remote-context world this inspects images on the remote host.
-	firstCtx := cfg.GetFirstContext()
-	client := factory.GetClientForContext(firstCtx, cfg)
-
-	return func(ctx context.Context, imageRef string) (string, error) {
+	return func(ctx context.Context, stackKey, imageRef string) (string, error) {
+		ctxName, _, err := manifest.ParseStackKey(stackKey)
+		if err != nil {
+			return "", nil //nolint:nilerr // best-effort
+		}
+		client := factory.GetClientForContext(ctxName, cfg)
 		out, err := client.ImageInspectRepoDigests(ctx, imageRef)
 		if err != nil {
 			// Image not pulled or inspect failed — treat as stale.
@@ -192,19 +193,22 @@ func makeLocalDigestFunc(cfg *manifest.Config, factory *dockercli.DefaultClientF
 	}
 }
 
-// prefetchLocalDigests calls localDigestFn sequentially for every image ref
-// across all inputs and returns a map of imageRef -> digest. This avoids
-// concurrent exec.Command calls to the Docker daemon which are unreliable
-// over SSH contexts.
+// prefetchLocalDigests calls localDigestFn sequentially for every (stack, image)
+// pair across all inputs and returns a map keyed by "stackKey|imageRef".
+// Keying by stack is required because different stacks may target different
+// Docker daemons, so the same image ref can have different local digests
+// (or be missing) depending on the daemon. Running exec.Command concurrently
+// (especially over SSH contexts) is also unreliable, hence sequential.
 func prefetchLocalDigests(ctx context.Context, inputs []images.CheckInput, fn images.LocalDigestFunc) map[string]string {
 	out := make(map[string]string)
 	for _, input := range inputs {
 		for _, imageRef := range input.Services {
-			if _, seen := out[imageRef]; seen {
+			key := input.StackKey + "|" + imageRef
+			if _, seen := out[key]; seen {
 				continue
 			}
-			digest, _ := fn(ctx, imageRef) // best-effort: empty string on failure
-			out[imageRef] = digest
+			digest, _ := fn(ctx, input.StackKey, imageRef) // best-effort: empty string on failure
+			out[key] = digest
 		}
 	}
 	return out

--- a/internal/cli/imagescmd/imagescmd_test.go
+++ b/internal/cli/imagescmd/imagescmd_test.go
@@ -43,7 +43,7 @@ func TestRenderTerminal_UpToDate(t *testing.T) {
 		{
 			Stack:       "default/web",
 			Service:     "nginx",
-			Image:       "nginx",
+			Image:       "nginx:1.25",
 			CurrentTag:  "1.25",
 			DigestStale: false,
 			NewerTags:   nil,
@@ -68,7 +68,7 @@ func TestRenderTerminal_NewerTagsAvailable(t *testing.T) {
 		{
 			Stack:       "default/web",
 			Service:     "nginx",
-			Image:       "nginx",
+			Image:       "nginx:1.25",
 			CurrentTag:  "1.25",
 			DigestStale: false,
 			NewerTags:   []string{"1.26", "1.27"},
@@ -136,7 +136,7 @@ func TestRenderTerminal_MultipleStacksGrouped(t *testing.T) {
 		{
 			Stack:      "default/frontend",
 			Service:    "nginx",
-			Image:      "nginx",
+			Image:      "nginx:1.25",
 			CurrentTag: "1.25",
 		},
 		{
@@ -162,8 +162,8 @@ func TestRenderTerminal_SameStackGroupedTogether(t *testing.T) {
 	pr := newTestPrinter(&buf)
 
 	results := []images.ImageStatus{
-		{Stack: "default/web", Service: "nginx", Image: "nginx", CurrentTag: "1.25"},
-		{Stack: "default/web", Service: "redis", Image: "redis", CurrentTag: "7"},
+		{Stack: "default/web", Service: "nginx", Image: "nginx:1.25", CurrentTag: "1.25"},
+		{Stack: "default/web", Service: "redis", Image: "redis:7", CurrentTag: "7"},
 	}
 	renderTerminal(pr, results)
 
@@ -186,7 +186,7 @@ func TestRenderJSON_BasicFields(t *testing.T) {
 		{
 			Stack:       "default/web",
 			Service:     "nginx",
-			Image:       "nginx",
+			Image:       "nginx:1.25",
 			CurrentTag:  "1.25",
 			DigestStale: true,
 			NewerTags:   []string{"1.26"},
@@ -213,8 +213,8 @@ func TestRenderJSON_BasicFields(t *testing.T) {
 	if r.Service != "nginx" {
 		t.Errorf("service: want %q, got %q", "nginx", r.Service)
 	}
-	if r.Image != "nginx" {
-		t.Errorf("image: want %q, got %q", "nginx", r.Image)
+	if r.Image != "nginx:1.25" {
+		t.Errorf("image: want %q, got %q", "nginx:1.25", r.Image)
 	}
 	if r.CurrentTag != "1.25" {
 		t.Errorf("current_tag: want %q, got %q", "1.25", r.CurrentTag)
@@ -236,7 +236,7 @@ func TestRenderJSON_EmptyNewerTagsOmitted(t *testing.T) {
 		{
 			Stack:      "default/web",
 			Service:    "nginx",
-			Image:      "nginx",
+			Image:      "nginx:1.25",
 			CurrentTag: "1.25",
 			NewerTags:  nil,
 		},
@@ -317,7 +317,7 @@ func TestRenderUpgradeTerminal_AlreadyLatest(t *testing.T) {
 		{
 			Stack:      "default/web",
 			Service:    "nginx",
-			Image:      "nginx",
+			Image:      "nginx:1.27",
 			CurrentTag: "1.27",
 			NewerTags:  nil,
 		},
@@ -363,7 +363,7 @@ func TestRenderUpgradeTerminal_ImageUpgraded(t *testing.T) {
 		{
 			Stack:      "default/web",
 			Service:    "nginx",
-			Image:      "nginx",
+			Image:      "nginx:1.25",
 			CurrentTag: "1.25",
 			NewerTags:  []string{"1.27"},
 		},
@@ -404,7 +404,7 @@ func TestRenderUpgradeTerminal_DryRun(t *testing.T) {
 		{
 			Stack:      "default/web",
 			Service:    "nginx",
-			Image:      "nginx",
+			Image:      "nginx:1.25",
 			CurrentTag: "1.25",
 			NewerTags:  []string{"1.27"},
 		},

--- a/internal/cli/imagescmd/imagescmd_test.go
+++ b/internal/cli/imagescmd/imagescmd_test.go
@@ -149,11 +149,11 @@ func TestRenderTerminal_MultipleStacksGrouped(t *testing.T) {
 	renderTerminal(pr, results)
 
 	got := stripANSI(buf.String())
-	if !strings.Contains(got, "Stack: default/frontend") {
-		t.Errorf("expected 'Stack: default/frontend' in output, got: %q", got)
+	if !strings.Contains(got, "default/frontend") {
+		t.Errorf("expected 'default/frontend' in output, got: %q", got)
 	}
-	if !strings.Contains(got, "Stack: default/backend") {
-		t.Errorf("expected 'Stack: default/backend' in output, got: %q", got)
+	if !strings.Contains(got, "default/backend") {
+		t.Errorf("expected 'default/backend' in output, got: %q", got)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestRenderTerminal_SameStackGroupedTogether(t *testing.T) {
 	renderTerminal(pr, results)
 
 	got := stripANSI(buf.String())
-	// "Stack: default/web" should appear exactly once
-	count := strings.Count(got, "Stack: default/web")
+	// "default/web" should appear exactly once
+	count := strings.Count(got, "default/web")
 	if count != 1 {
 		t.Errorf("expected stack header to appear once, got %d occurrences in: %q", count, got)
 	}

--- a/internal/cli/imagescmd/imagescmd_test.go
+++ b/internal/cli/imagescmd/imagescmd_test.go
@@ -1,0 +1,536 @@
+package imagescmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gcstr/dockform/internal/images"
+	"github.com/gcstr/dockform/internal/manifest"
+	"github.com/gcstr/dockform/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// newTestPrinter returns a Printer backed by a buffer for capturing output.
+func newTestPrinter(buf *bytes.Buffer) ui.Printer {
+	return ui.StdPrinter{Out: buf, Err: buf}
+}
+
+// stripANSI removes ANSI escape codes from a string for portable assertions.
+func stripANSI(s string) string {
+	return ui.StripANSI(s)
+}
+
+// --- renderTerminal tests ---
+
+func TestRenderTerminal_EmptyResults(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+	renderTerminal(pr, nil)
+
+	got := buf.String()
+	if !strings.Contains(got, "No images found.") {
+		t.Errorf("expected 'No images found.' for empty results, got: %q", got)
+	}
+}
+
+func TestRenderTerminal_UpToDate(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:       "default/web",
+			Service:     "nginx",
+			Image:       "nginx",
+			CurrentTag:  "1.25",
+			DigestStale: false,
+			NewerTags:   nil,
+		},
+	}
+	renderTerminal(pr, results)
+
+	got := stripANSI(buf.String())
+	if !strings.Contains(got, "up to date") {
+		t.Errorf("expected 'up to date', got: %q", got)
+	}
+	if !strings.Contains(got, "nginx:1.25") {
+		t.Errorf("expected 'nginx:1.25' in output, got: %q", got)
+	}
+}
+
+func TestRenderTerminal_NewerTagsAvailable(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:       "default/web",
+			Service:     "nginx",
+			Image:       "nginx",
+			CurrentTag:  "1.25",
+			DigestStale: false,
+			NewerTags:   []string{"1.26", "1.27"},
+		},
+	}
+	renderTerminal(pr, results)
+
+	got := stripANSI(buf.String())
+	if !strings.Contains(got, "newer versions:") {
+		t.Errorf("expected 'newer versions:' in output, got: %q", got)
+	}
+	if !strings.Contains(got, "1.26") || !strings.Contains(got, "1.27") {
+		t.Errorf("expected newer tags in output, got: %q", got)
+	}
+}
+
+func TestRenderTerminal_DigestStaleOnly(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:       "default/web",
+			Service:     "redis",
+			Image:       "redis",
+			CurrentTag:  "7",
+			DigestStale: true,
+			NewerTags:   nil,
+		},
+	}
+	renderTerminal(pr, results)
+
+	got := stripANSI(buf.String())
+	if !strings.Contains(got, "updated upstream") {
+		t.Errorf("expected 'updated upstream' for digest-stale image, got: %q", got)
+	}
+}
+
+func TestRenderTerminal_ImageWithError(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:      "default/web",
+			Service:    "app",
+			Image:      "myapp",
+			CurrentTag: "latest",
+			Error:      "registry timeout",
+		},
+	}
+	renderTerminal(pr, results)
+
+	got := stripANSI(buf.String())
+	if !strings.Contains(got, "registry timeout") {
+		t.Errorf("expected error message in output, got: %q", got)
+	}
+}
+
+func TestRenderTerminal_MultipleStacksGrouped(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:      "default/frontend",
+			Service:    "nginx",
+			Image:      "nginx",
+			CurrentTag: "1.25",
+		},
+		{
+			Stack:      "default/backend",
+			Service:    "api",
+			Image:      "myapi",
+			CurrentTag: "v2",
+		},
+	}
+	renderTerminal(pr, results)
+
+	got := stripANSI(buf.String())
+	if !strings.Contains(got, "Stack: default/frontend") {
+		t.Errorf("expected 'Stack: default/frontend' in output, got: %q", got)
+	}
+	if !strings.Contains(got, "Stack: default/backend") {
+		t.Errorf("expected 'Stack: default/backend' in output, got: %q", got)
+	}
+}
+
+func TestRenderTerminal_SameStackGroupedTogether(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{Stack: "default/web", Service: "nginx", Image: "nginx", CurrentTag: "1.25"},
+		{Stack: "default/web", Service: "redis", Image: "redis", CurrentTag: "7"},
+	}
+	renderTerminal(pr, results)
+
+	got := stripANSI(buf.String())
+	// "Stack: default/web" should appear exactly once
+	count := strings.Count(got, "Stack: default/web")
+	if count != 1 {
+		t.Errorf("expected stack header to appear once, got %d occurrences in: %q", count, got)
+	}
+}
+
+// --- renderJSON tests ---
+
+func TestRenderJSON_BasicFields(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:       "default/web",
+			Service:     "nginx",
+			Image:       "nginx",
+			CurrentTag:  "1.25",
+			DigestStale: true,
+			NewerTags:   []string{"1.26"},
+		},
+	}
+
+	if err := renderJSON(cmd, results); err != nil {
+		t.Fatalf("renderJSON returned error: %v", err)
+	}
+
+	var out []jsonResult
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\nraw: %s", err, buf.String())
+	}
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(out))
+	}
+
+	r := out[0]
+	if r.Stack != "default/web" {
+		t.Errorf("stack: want %q, got %q", "default/web", r.Stack)
+	}
+	if r.Service != "nginx" {
+		t.Errorf("service: want %q, got %q", "nginx", r.Service)
+	}
+	if r.Image != "nginx" {
+		t.Errorf("image: want %q, got %q", "nginx", r.Image)
+	}
+	if r.CurrentTag != "1.25" {
+		t.Errorf("current_tag: want %q, got %q", "1.25", r.CurrentTag)
+	}
+	if !r.DigestChanged {
+		t.Errorf("digest_changed: want true, got false")
+	}
+	if len(r.NewerTags) != 1 || r.NewerTags[0] != "1.26" {
+		t.Errorf("newer_tags: want [1.26], got %v", r.NewerTags)
+	}
+}
+
+func TestRenderJSON_EmptyNewerTagsOmitted(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:      "default/web",
+			Service:    "nginx",
+			Image:      "nginx",
+			CurrentTag: "1.25",
+			NewerTags:  nil,
+		},
+	}
+
+	if err := renderJSON(cmd, results); err != nil {
+		t.Fatalf("renderJSON returned error: %v", err)
+	}
+
+	// newer_tags should be omitted from JSON when empty (omitempty)
+	raw := buf.String()
+	if strings.Contains(raw, "newer_tags") {
+		t.Errorf("expected newer_tags to be omitted when nil, but found it in: %s", raw)
+	}
+}
+
+func TestRenderJSON_ErrorField(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:   "default/web",
+			Service: "app",
+			Image:   "myapp",
+			Error:   "connection refused",
+		},
+	}
+
+	if err := renderJSON(cmd, results); err != nil {
+		t.Fatalf("renderJSON returned error: %v", err)
+	}
+
+	var out []jsonResult
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+
+	if len(out) != 1 || out[0].Error != "connection refused" {
+		t.Errorf("expected error field 'connection refused', got: %+v", out)
+	}
+}
+
+func TestRenderJSON_EmptyResults(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := renderJSON(cmd, []images.ImageStatus{}); err != nil {
+		t.Fatalf("renderJSON returned error: %v", err)
+	}
+
+	raw := strings.TrimSpace(buf.String())
+	if raw != "[]" {
+		t.Errorf("expected '[]' for empty results, got: %s", raw)
+	}
+}
+
+// --- renderUpgradeTerminal tests ---
+
+func TestRenderUpgradeTerminal_EmptyResults(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+	renderUpgradeTerminal(pr, nil, nil, nil, false)
+
+	got := buf.String()
+	if !strings.Contains(got, "No images found.") {
+		t.Errorf("expected 'No images found.', got: %q", got)
+	}
+}
+
+func TestRenderUpgradeTerminal_AlreadyLatest(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:      "default/web",
+			Service:    "nginx",
+			Image:      "nginx",
+			CurrentTag: "1.27",
+			NewerTags:  nil,
+		},
+	}
+	renderUpgradeTerminal(pr, results, nil, map[string][]string{}, false)
+
+	got := stripANSI(buf.String())
+	if !strings.Contains(got, "already latest") {
+		t.Errorf("expected 'already latest', got: %q", got)
+	}
+}
+
+func TestRenderUpgradeTerminal_DigestStaleNoTagPattern(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:       "default/web",
+			Service:     "redis",
+			Image:       "redis",
+			CurrentTag:  "7",
+			DigestStale: true,
+			NewerTags:   nil,
+		},
+	}
+	renderUpgradeTerminal(pr, results, nil, map[string][]string{}, false)
+
+	got := stripANSI(buf.String())
+	if !strings.Contains(got, "no tag_pattern configured") {
+		t.Errorf("expected 'no tag_pattern configured', got: %q", got)
+	}
+	if !strings.Contains(got, "docker compose pull") {
+		t.Errorf("expected 'docker compose pull' hint, got: %q", got)
+	}
+}
+
+func TestRenderUpgradeTerminal_ImageUpgraded(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:      "default/web",
+			Service:    "nginx",
+			Image:      "nginx",
+			CurrentTag: "1.25",
+			NewerTags:  []string{"1.27"},
+		},
+	}
+	changes := []images.FileChange{
+		{
+			StackKey: "default/web",
+			Service:  "nginx",
+			File:     "/app/docker-compose.yaml",
+			Image:    "nginx",
+			OldTag:   "1.25",
+			NewTag:   "1.27",
+		},
+	}
+	stackFiles := map[string][]string{
+		"default/web": {"/app/docker-compose.yaml"},
+	}
+
+	renderUpgradeTerminal(pr, results, changes, stackFiles, false)
+
+	got := stripANSI(buf.String())
+	if !strings.Contains(got, "nginx:1.25") {
+		t.Errorf("expected old ref 'nginx:1.25', got: %q", got)
+	}
+	if !strings.Contains(got, "nginx:1.27") {
+		t.Errorf("expected new ref 'nginx:1.27', got: %q", got)
+	}
+	if !strings.Contains(got, "docker-compose.yaml updated") {
+		t.Errorf("expected '(docker-compose.yaml updated)', got: %q", got)
+	}
+}
+
+func TestRenderUpgradeTerminal_DryRun(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:      "default/web",
+			Service:    "nginx",
+			Image:      "nginx",
+			CurrentTag: "1.25",
+			NewerTags:  []string{"1.27"},
+		},
+	}
+	stackFiles := map[string][]string{
+		"default/web": {"/app/docker-compose.yaml"},
+	}
+
+	// No changes (dry run — Upgrade was not called)
+	renderUpgradeTerminal(pr, results, nil, stackFiles, true)
+
+	got := stripANSI(buf.String())
+	if !strings.Contains(got, "dry run") {
+		t.Errorf("expected '(dry run)' in output, got: %q", got)
+	}
+}
+
+func TestRenderUpgradeTerminal_ImageWithError(t *testing.T) {
+	var buf bytes.Buffer
+	pr := newTestPrinter(&buf)
+
+	results := []images.ImageStatus{
+		{
+			Stack:      "default/web",
+			Service:    "app",
+			Image:      "myapp",
+			CurrentTag: "v1",
+			Error:      "name unknown",
+		},
+	}
+	renderUpgradeTerminal(pr, results, nil, map[string][]string{}, false)
+
+	got := stripANSI(buf.String())
+	if !strings.Contains(got, "name unknown") {
+		t.Errorf("expected error message, got: %q", got)
+	}
+}
+
+// --- buildStackFiles tests ---
+
+func TestBuildStackFiles_AbsolutePaths(t *testing.T) {
+	cfg := &manifest.Config{
+		Stacks: map[string]manifest.Stack{
+			"default/web": {
+				RootAbs: "/srv/app",
+				Files:   []string{"/srv/app/docker-compose.yaml"},
+			},
+		},
+	}
+
+	result := buildStackFiles(cfg)
+	paths, ok := result["default/web"]
+	if !ok {
+		t.Fatal("expected key 'default/web' in result")
+	}
+	if len(paths) != 1 || paths[0] != "/srv/app/docker-compose.yaml" {
+		t.Errorf("expected [/srv/app/docker-compose.yaml], got %v", paths)
+	}
+}
+
+func TestBuildStackFiles_RelativePaths(t *testing.T) {
+	cfg := &manifest.Config{
+		Stacks: map[string]manifest.Stack{
+			"default/web": {
+				RootAbs: "/srv/app",
+				Files:   []string{"docker-compose.yaml", "docker-compose.override.yaml"},
+			},
+		},
+	}
+
+	result := buildStackFiles(cfg)
+	paths := result["default/web"]
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d: %v", len(paths), paths)
+	}
+	if paths[0] != "/srv/app/docker-compose.yaml" {
+		t.Errorf("path[0]: want %q, got %q", "/srv/app/docker-compose.yaml", paths[0])
+	}
+	if paths[1] != "/srv/app/docker-compose.override.yaml" {
+		t.Errorf("path[1]: want %q, got %q", "/srv/app/docker-compose.override.yaml", paths[1])
+	}
+}
+
+func TestBuildStackFiles_MultipleStacks(t *testing.T) {
+	cfg := &manifest.Config{
+		Stacks: map[string]manifest.Stack{
+			"default/web": {
+				RootAbs: "/srv/web",
+				Files:   []string{"compose.yaml"},
+			},
+			"default/db": {
+				RootAbs: "/srv/db",
+				Files:   []string{"compose.yaml"},
+			},
+		},
+	}
+
+	result := buildStackFiles(cfg)
+	if len(result) != 2 {
+		t.Errorf("expected 2 stacks in result, got %d", len(result))
+	}
+
+	webPaths := result["default/web"]
+	if len(webPaths) != 1 || webPaths[0] != "/srv/web/compose.yaml" {
+		t.Errorf("web paths: want [/srv/web/compose.yaml], got %v", webPaths)
+	}
+
+	dbPaths := result["default/db"]
+	if len(dbPaths) != 1 || dbPaths[0] != "/srv/db/compose.yaml" {
+		t.Errorf("db paths: want [/srv/db/compose.yaml], got %v", dbPaths)
+	}
+}
+
+func TestBuildStackFiles_EmptyFiles(t *testing.T) {
+	cfg := &manifest.Config{
+		Stacks: map[string]manifest.Stack{
+			"default/web": {
+				RootAbs: "/srv/app",
+				Files:   []string{},
+			},
+		},
+	}
+
+	result := buildStackFiles(cfg)
+	paths := result["default/web"]
+	if len(paths) != 0 {
+		t.Errorf("expected empty paths, got %v", paths)
+	}
+}

--- a/internal/cli/imagescmd/imagescmd_test.go
+++ b/internal/cli/imagescmd/imagescmd_test.go
@@ -27,7 +27,7 @@ func stripANSI(s string) string {
 func TestRenderTerminal_EmptyResults(t *testing.T) {
 	var buf bytes.Buffer
 	pr := newTestPrinter(&buf)
-	renderTerminal(pr, nil)
+	renderTerminal(pr, nil, false)
 
 	got := buf.String()
 	if !strings.Contains(got, "No images found.") {
@@ -49,14 +49,14 @@ func TestRenderTerminal_UpToDate(t *testing.T) {
 			NewerTags:   nil,
 		},
 	}
-	renderTerminal(pr, results)
+	renderTerminal(pr, results, true)
 
 	got := stripANSI(buf.String())
 	if !strings.Contains(got, "up to date") {
 		t.Errorf("expected 'up to date', got: %q", got)
 	}
-	if !strings.Contains(got, "nginx:1.25") {
-		t.Errorf("expected 'nginx:1.25' in output, got: %q", got)
+	if !strings.Contains(got, "nginx") {
+		t.Errorf("expected 'nginx' in output, got: %q", got)
 	}
 }
 
@@ -74,11 +74,11 @@ func TestRenderTerminal_NewerTagsAvailable(t *testing.T) {
 			NewerTags:   []string{"1.26", "1.27"},
 		},
 	}
-	renderTerminal(pr, results)
+	renderTerminal(pr, results, false)
 
 	got := stripANSI(buf.String())
-	if !strings.Contains(got, "newer versions:") {
-		t.Errorf("expected 'newer versions:' in output, got: %q", got)
+	if !strings.Contains(got, "newer:") {
+		t.Errorf("expected 'newer:' in output, got: %q", got)
 	}
 	if !strings.Contains(got, "1.26") || !strings.Contains(got, "1.27") {
 		t.Errorf("expected newer tags in output, got: %q", got)
@@ -99,7 +99,7 @@ func TestRenderTerminal_DigestStaleOnly(t *testing.T) {
 			NewerTags:   nil,
 		},
 	}
-	renderTerminal(pr, results)
+	renderTerminal(pr, results, false)
 
 	got := stripANSI(buf.String())
 	if !strings.Contains(got, "updated upstream") {
@@ -120,7 +120,7 @@ func TestRenderTerminal_ImageWithError(t *testing.T) {
 			Error:      "registry timeout",
 		},
 	}
-	renderTerminal(pr, results)
+	renderTerminal(pr, results, false)
 
 	got := stripANSI(buf.String())
 	if !strings.Contains(got, "registry timeout") {
@@ -146,7 +146,7 @@ func TestRenderTerminal_MultipleStacksGrouped(t *testing.T) {
 			CurrentTag: "v2",
 		},
 	}
-	renderTerminal(pr, results)
+	renderTerminal(pr, results, true)
 
 	got := stripANSI(buf.String())
 	if !strings.Contains(got, "default/frontend") {
@@ -165,13 +165,15 @@ func TestRenderTerminal_SameStackGroupedTogether(t *testing.T) {
 		{Stack: "default/web", Service: "nginx", Image: "nginx:1.25", CurrentTag: "1.25"},
 		{Stack: "default/web", Service: "redis", Image: "redis:7", CurrentTag: "7"},
 	}
-	renderTerminal(pr, results)
+	renderTerminal(pr, results, true)
 
 	got := stripANSI(buf.String())
-	// "default/web" should appear exactly once
-	count := strings.Count(got, "default/web")
-	if count != 1 {
-		t.Errorf("expected stack header to appear once, got %d occurrences in: %q", count, got)
+	// Both services should appear in the flat table.
+	if !strings.Contains(got, "nginx") {
+		t.Errorf("expected 'nginx' row in output, got: %q", got)
+	}
+	if !strings.Contains(got, "redis") {
+		t.Errorf("expected 'redis' row in output, got: %q", got)
 	}
 }
 

--- a/internal/cli/imagescmd/new.go
+++ b/internal/cli/imagescmd/new.go
@@ -9,5 +9,6 @@ func New() *cobra.Command {
 		Short: "Manage and check container images",
 	}
 	cmd.AddCommand(newCheckCmd())
+	cmd.AddCommand(newUpgradeCmd())
 	return cmd
 }

--- a/internal/cli/imagescmd/new.go
+++ b/internal/cli/imagescmd/new.go
@@ -1,0 +1,13 @@
+package imagescmd
+
+import "github.com/spf13/cobra"
+
+// New returns the "images" parent command with subcommands.
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "Manage and check container images",
+	}
+	cmd.AddCommand(newCheckCmd())
+	return cmd
+}

--- a/internal/cli/imagescmd/upgrade.go
+++ b/internal/cli/imagescmd/upgrade.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/gcstr/dockform/internal/cli/common"
 	"github.com/gcstr/dockform/internal/images"
 	"github.com/gcstr/dockform/internal/manifest"
@@ -151,12 +152,12 @@ func renderUpgradeTerminal(pr ui.Printer, results []images.ImageStatus, changes 
 		return groups[i].key < groups[j].key
 	})
 
+	boldStyle := lipgloss.NewStyle().Bold(true)
 	for i, g := range groups {
 		if i > 0 {
 			pr.Plain("")
 		}
-		pr.Plain("Stack: %s", g.key)
-		pr.Plain("")
+		pr.Plain("%s", boldStyle.Render(g.key))
 
 		for _, r := range g.results {
 			imageRef := r.Image

--- a/internal/cli/imagescmd/upgrade.go
+++ b/internal/cli/imagescmd/upgrade.go
@@ -160,12 +160,9 @@ func renderUpgradeTerminal(pr ui.Printer, results []images.ImageStatus, changes 
 
 		for _, r := range g.results {
 			imageRef := r.Image
-			if r.CurrentTag != "" && !strings.Contains(r.Image, ":") {
-				imageRef = r.Image + ":" + r.CurrentTag
-			}
 
 			if r.Error != "" {
-				pr.Plain("  %-40s %s %s", imageRef, ui.YellowText("!"), r.Error)
+				pr.Plain("  %-40s %s %s", imageRef, ui.YellowText("⚠"), r.Error)
 				continue
 			}
 
@@ -191,11 +188,11 @@ func renderUpgradeTerminal(pr ui.Printer, results []images.ImageStatus, changes 
 					if len(files) > 0 {
 						pr.Plain("  %s → %s   (dry run)", imageRef, newRef)
 					} else {
-						pr.Plain("  %-40s %s tag not found in compose file", imageRef+" → "+newRef, ui.YellowText("!"))
+						pr.Plain("  %-40s %s tag not found in compose file", imageRef+" → "+newRef, ui.YellowText("⚠"))
 					}
 				} else {
 					// Upgrade ran but image wasn't found in files.
-					pr.Plain("  %-40s %s tag not found in compose file", imageRef+" → "+newRef, ui.YellowText("!"))
+					pr.Plain("  %-40s %s tag not found in compose file", imageRef+" → "+newRef, ui.YellowText("⚠"))
 				}
 				continue
 			}

--- a/internal/cli/imagescmd/upgrade.go
+++ b/internal/cli/imagescmd/upgrade.go
@@ -69,11 +69,9 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 	localDigestFn := makeLocalDigestFunc(cfg, factory)
 
 	// Run the check.
-	sequential, _ := cmd.Flags().GetBool("sequential")
-
 	var results []images.ImageStatus
 	err = common.SpinnerOperation(pr, "Checking images...", func() error {
-		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn, sequential)
+		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn)
 		return err
 	})
 	if err != nil {

--- a/internal/cli/imagescmd/upgrade.go
+++ b/internal/cli/imagescmd/upgrade.go
@@ -69,9 +69,11 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 	localDigestFn := makeLocalDigestFunc(cfg, factory)
 
 	// Run the check.
+	sequential, _ := cmd.Flags().GetBool("sequential")
+
 	var results []images.ImageStatus
 	err = common.SpinnerOperation(pr, "Checking images...", func() error {
-		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn)
+		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn, sequential)
 		return err
 	})
 	if err != nil {

--- a/internal/cli/imagescmd/upgrade.go
+++ b/internal/cli/imagescmd/upgrade.go
@@ -1,0 +1,211 @@
+package imagescmd
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gcstr/dockform/internal/cli/common"
+	"github.com/gcstr/dockform/internal/images"
+	"github.com/gcstr/dockform/internal/manifest"
+	"github.com/gcstr/dockform/internal/registry"
+	"github.com/gcstr/dockform/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func newUpgradeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade image tags in compose files to the newest available versions",
+		RunE:  runUpgrade,
+	}
+
+	cmd.Flags().Bool("dry-run", false, "Preview changes without writing files")
+
+	common.AddTargetFlags(cmd)
+
+	return cmd
+}
+
+func runUpgrade(cmd *cobra.Command, _ []string) error {
+	pr := ui.StdPrinter{Out: cmd.OutOrStdout(), Err: cmd.ErrOrStderr()}
+
+	// Load configuration with warnings.
+	cfg, err := common.LoadConfigWithWarnings(cmd, pr)
+	if err != nil {
+		return err
+	}
+
+	// Apply target filtering if flags are provided.
+	opts := common.ReadTargetOptions(cmd)
+	if !opts.IsEmpty() {
+		cfg, err = common.ResolveTargets(cfg, opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	common.DisplayDaemonInfo(pr, cfg)
+
+	// Create client factory for multi-context support.
+	factory := common.CreateClientFactory()
+
+	// Create registry client.
+	reg := registry.NewOCIClient(nil)
+
+	// Build check inputs from all stacks.
+	inputs, err := buildCheckInputs(cmd.Context(), cfg, factory)
+	if err != nil {
+		return err
+	}
+
+	if len(inputs) == 0 {
+		pr.Plain("\nNo stacks with images found.")
+		return nil
+	}
+
+	// Build a local digest function using the factory.
+	localDigestFn := makeLocalDigestFunc(cfg, factory)
+
+	// Run the check.
+	var results []images.ImageStatus
+	err = common.SpinnerOperation(pr, "Checking images...", func() error {
+		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	// Build stackFiles map: stack key -> list of absolute compose file paths.
+	stackFiles := buildStackFiles(cfg)
+
+	var changes []images.FileChange
+	if !dryRun {
+		changes, err = images.Upgrade(results, stackFiles)
+		if err != nil {
+			return err
+		}
+	}
+
+	renderUpgradeTerminal(pr, results, changes, stackFiles, dryRun)
+	return nil
+}
+
+// buildStackFiles builds a map of stack key to absolute compose file paths.
+func buildStackFiles(cfg *manifest.Config) map[string][]string {
+	allStacks := cfg.GetAllStacks()
+	stackFiles := make(map[string][]string, len(allStacks))
+
+	for stackKey, stack := range allStacks {
+		paths := make([]string, 0, len(stack.Files))
+		for _, f := range stack.Files {
+			if filepath.IsAbs(f) {
+				paths = append(paths, f)
+			} else {
+				paths = append(paths, filepath.Join(stack.RootAbs, f))
+			}
+		}
+		stackFiles[stackKey] = paths
+	}
+
+	return stackFiles
+}
+
+func renderUpgradeTerminal(pr ui.Printer, results []images.ImageStatus, changes []images.FileChange, stackFiles map[string][]string, dryRun bool) {
+	if len(results) == 0 {
+		pr.Plain("\nNo images found.")
+		return
+	}
+
+	// Build a quick lookup: (stack, service) -> FileChange
+	type changeKey struct{ stack, service string }
+	changeMap := make(map[changeKey]images.FileChange, len(changes))
+	for _, c := range changes {
+		changeMap[changeKey{c.StackKey, c.Service}] = c
+	}
+
+	// Group results by stack for display.
+	type stackGroup struct {
+		key     string
+		results []images.ImageStatus
+	}
+
+	seen := make(map[string]int)
+	var groups []stackGroup
+
+	for _, r := range results {
+		idx, ok := seen[r.Stack]
+		if !ok {
+			idx = len(groups)
+			seen[r.Stack] = idx
+			groups = append(groups, stackGroup{key: r.Stack})
+		}
+		groups[idx].results = append(groups[idx].results, r)
+	}
+
+	// Sort groups for deterministic output.
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].key < groups[j].key
+	})
+
+	for i, g := range groups {
+		if i > 0 {
+			pr.Plain("")
+		}
+		pr.Plain("Stack: %s", g.key)
+		pr.Plain("")
+
+		for _, r := range g.results {
+			imageRef := r.Image
+			if r.CurrentTag != "" && !strings.Contains(r.Image, ":") {
+				imageRef = r.Image + ":" + r.CurrentTag
+			}
+
+			if r.Error != "" {
+				pr.Plain("  %-40s %s %s", imageRef, ui.YellowText("!"), r.Error)
+				continue
+			}
+
+			if len(r.NewerTags) > 0 {
+				newTag := r.NewerTags[0]
+
+				// Derive image name without tag.
+				imageName := r.Image
+				if idx := strings.LastIndex(r.Image, ":"); idx != -1 {
+					imageName = r.Image[:idx]
+				}
+
+				newRef := imageName + ":" + newTag
+
+				ck := changeKey{r.Stack, r.Service}
+				if fc, ok := changeMap[ck]; ok {
+					// File was updated (real run).
+					composeFile := filepath.Base(fc.File)
+					pr.Plain("  %s → %s   (%s updated)", imageRef, newRef, composeFile)
+				} else if dryRun {
+					// Check if it would be found in compose files.
+					files := stackFiles[r.Stack]
+					if len(files) > 0 {
+						pr.Plain("  %s → %s   (dry run)", imageRef, newRef)
+					} else {
+						pr.Plain("  %-40s %s tag not found in compose file", imageRef+" → "+newRef, ui.YellowText("!"))
+					}
+				} else {
+					// Upgrade ran but image wasn't found in files.
+					pr.Plain("  %-40s %s tag not found in compose file", imageRef+" → "+newRef, ui.YellowText("!"))
+				}
+				continue
+			}
+
+			if r.DigestStale && len(r.NewerTags) == 0 && r.Error == "" {
+				pr.Plain("  %-40s %s no tag_pattern configured — run `docker compose pull`", imageRef, ui.YellowText("⚠"))
+				continue
+			}
+
+			pr.Plain("  %-40s %s already latest", imageRef, ui.GreenText("✓"))
+		}
+	}
+}

--- a/internal/cli/imagescmd/upgrade.go
+++ b/internal/cli/imagescmd/upgrade.go
@@ -72,8 +72,8 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 	// Run the check.
 	var results []images.ImageStatus
 	err = common.SpinnerOperation(pr, "Checking images...", func() error {
-		results, err = images.Check(cmd.Context(), inputs, reg, func(ctx context.Context, imageRef string) (string, error) {
-			return localDigests[imageRef], nil
+		results, err = images.Check(cmd.Context(), inputs, reg, func(ctx context.Context, stackKey, imageRef string) (string, error) {
+			return localDigests[stackKey+"|"+imageRef], nil
 		})
 		return err
 	})

--- a/internal/cli/imagescmd/upgrade.go
+++ b/internal/cli/imagescmd/upgrade.go
@@ -1,6 +1,7 @@
 package imagescmd
 
 import (
+	"context"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -65,13 +66,15 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	// Build a local digest function using the factory.
-	localDigestFn := makeLocalDigestFunc(cfg, factory)
+	// Pre-fetch local digests sequentially before parallel registry checks.
+	localDigests := prefetchLocalDigests(cmd.Context(), inputs, makeLocalDigestFunc(cfg, factory))
 
 	// Run the check.
 	var results []images.ImageStatus
 	err = common.SpinnerOperation(pr, "Checking images...", func() error {
-		results, err = images.Check(cmd.Context(), inputs, reg, localDigestFn)
+		results, err = images.Check(cmd.Context(), inputs, reg, func(ctx context.Context, imageRef string) (string, error) {
+			return localDigests[imageRef], nil
+		})
 		return err
 	})
 	if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gcstr/dockform/internal/cli/buildinfo"
 	"github.com/gcstr/dockform/internal/cli/composecmd"
 	"github.com/gcstr/dockform/internal/cli/dashboardcmd"
+	"github.com/gcstr/dockform/internal/cli/imagescmd"
 	"github.com/gcstr/dockform/internal/cli/destroycmd"
 	"github.com/gcstr/dockform/internal/cli/doctorcmd"
 	"github.com/gcstr/dockform/internal/cli/initcmd"
@@ -120,6 +121,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(volumecmd.New())
 	cmd.AddCommand(doctorcmd.New())
 	cmd.AddCommand(dashboardcmd.New())
+	cmd.AddCommand(imagescmd.New())
 
 	// Register optional developer-only commands
 	registerDocsCmd(cmd)

--- a/internal/dockercli/info.go
+++ b/internal/dockercli/info.go
@@ -2,6 +2,7 @@ package dockercli
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 )
 
@@ -49,6 +50,23 @@ func (c *Client) ComposeVersion(ctx context.Context) (string, error) {
 		return "", err2
 	}
 	return strings.TrimSpace(out2), nil
+}
+
+// ImageInspectRepoDigests returns the RepoDigests list for a local image.
+// Returns nil and an error if the image is not found or inspect fails.
+func (c *Client) ImageInspectRepoDigests(ctx context.Context, imageRef string) ([]string, error) {
+	if strings.TrimSpace(imageRef) == "" {
+		return nil, nil
+	}
+	out, err := c.exec.Run(ctx, "image", "inspect", "--format", "{{json .RepoDigests}}", imageRef)
+	if err != nil {
+		return nil, err
+	}
+	var digests []string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &digests); err != nil {
+		return nil, err
+	}
+	return digests, nil
 }
 
 // ImageExists returns true if the given image is present locally in the configured context.

--- a/internal/images/check.go
+++ b/internal/images/check.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"regexp"
 	"sort"
-	"sync"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gcstr/dockform/internal/registry"
@@ -15,45 +14,23 @@ import (
 //
 // Errors for individual images are captured in ImageStatus.Error so that a
 // single failing image does not abort the entire check.
-//
-// When sequential is false (the default), all images are checked concurrently.
-func Check(ctx context.Context, inputs []CheckInput, reg registry.Registry, localDigestFn LocalDigestFunc, sequential bool) ([]ImageStatus, error) {
-	// Flatten all (input, svcName) pairs first so we can preserve order.
-	type work struct {
-		input   CheckInput
-		svcName string
-	}
+func Check(ctx context.Context, inputs []CheckInput, reg registry.Registry, localDigestFn LocalDigestFunc) ([]ImageStatus, error) {
+	var results []ImageStatus
 
-	var jobs []work
 	for _, input := range inputs {
+		// Sort service names for deterministic output.
 		svcNames := make([]string, 0, len(input.Services))
 		for name := range input.Services {
 			svcNames = append(svcNames, name)
 		}
 		sort.Strings(svcNames)
+
 		for _, svcName := range svcNames {
-			jobs = append(jobs, work{input, svcName})
+			imageStr := input.Services[svcName]
+			status := checkImage(ctx, input.StackKey, svcName, imageStr, input.TagPattern, reg, localDigestFn)
+			results = append(results, status)
 		}
 	}
-
-	results := make([]ImageStatus, len(jobs))
-
-	if sequential {
-		for i, j := range jobs {
-			results[i] = checkImage(ctx, j.input.StackKey, j.svcName, j.input.Services[j.svcName], j.input.TagPattern, reg, localDigestFn)
-		}
-		return results, nil
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(len(jobs))
-	for i, j := range jobs {
-		go func(idx int, job work) {
-			defer wg.Done()
-			results[idx] = checkImage(ctx, job.input.StackKey, job.svcName, job.input.Services[job.svcName], job.input.TagPattern, reg, localDigestFn)
-		}(i, j)
-	}
-	wg.Wait()
 
 	return results, nil
 }

--- a/internal/images/check.go
+++ b/internal/images/check.go
@@ -1,0 +1,137 @@
+package images
+
+import (
+	"context"
+	"regexp"
+	"sort"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/gcstr/dockform/internal/registry"
+)
+
+// Check scans all images across the provided inputs and compares them against
+// registries for digest staleness and newer semver tags.
+//
+// Errors for individual images are captured in ImageStatus.Error so that a
+// single failing image does not abort the entire check.
+func Check(ctx context.Context, inputs []CheckInput, reg registry.Registry, localDigestFn LocalDigestFunc) ([]ImageStatus, error) {
+	var results []ImageStatus
+
+	for _, input := range inputs {
+		// Sort service names for deterministic output.
+		svcNames := make([]string, 0, len(input.Services))
+		for name := range input.Services {
+			svcNames = append(svcNames, name)
+		}
+		sort.Strings(svcNames)
+
+		for _, svcName := range svcNames {
+			imageStr := input.Services[svcName]
+			status := checkImage(ctx, input.StackKey, svcName, imageStr, input.TagPattern, reg, localDigestFn)
+			results = append(results, status)
+		}
+	}
+
+	return results, nil
+}
+
+func checkImage(
+	ctx context.Context,
+	stackKey, svcName, imageStr, tagPattern string,
+	reg registry.Registry,
+	localDigestFn LocalDigestFunc,
+) ImageStatus {
+	status := ImageStatus{
+		Stack:   stackKey,
+		Service: svcName,
+		Image:   imageStr,
+	}
+
+	ref, err := registry.ParseImageRef(imageStr)
+	if err != nil {
+		status.Error = err.Error()
+		return status
+	}
+	status.CurrentTag = ref.Tag
+
+	// Compare digests.
+	remoteDigest, err := reg.GetRemoteDigest(ctx, ref, ref.Tag)
+	if err != nil {
+		status.Error = err.Error()
+		return status
+	}
+
+	localDigest, err := localDigestFn(ctx, imageStr)
+	if err != nil {
+		status.Error = err.Error()
+		return status
+	}
+
+	status.DigestStale = remoteDigest != localDigest
+
+	// Tag comparison (only when a pattern is configured).
+	if tagPattern == "" {
+		return status
+	}
+
+	newerTags, err := findNewerTags(ctx, reg, ref, tagPattern)
+	if err != nil {
+		status.Error = err.Error()
+		return status
+	}
+	status.NewerTags = newerTags
+
+	return status
+}
+
+// findNewerTags lists remote tags, filters by the regex pattern, parses them as
+// semver, and returns those newer than the current tag sorted descending.
+// If the current tag is not valid semver, it returns nil (digest-only).
+func findNewerTags(ctx context.Context, reg registry.Registry, ref registry.ImageRef, tagPattern string) ([]string, error) {
+	currentVer, err := semver.NewVersion(ref.Tag)
+	if err != nil {
+		// Current tag is not valid semver — skip tag comparison.
+		return nil, nil
+	}
+
+	re, err := regexp.Compile(tagPattern)
+	if err != nil {
+		return nil, err
+	}
+
+	allTags, err := reg.ListTags(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	type tagVersion struct {
+		tag string
+		ver *semver.Version
+	}
+
+	var candidates []tagVersion
+	for _, t := range allTags {
+		if !re.MatchString(t) {
+			continue
+		}
+		v, parseErr := semver.NewVersion(t)
+		if parseErr != nil {
+			continue
+		}
+		if v.GreaterThan(currentVer) {
+			candidates = append(candidates, tagVersion{tag: t, ver: v})
+		}
+	}
+
+	// Sort descending (newest first).
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ver.GreaterThan(candidates[j].ver)
+	})
+
+	newer := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		newer = append(newer, c.tag)
+	}
+
+	return newer, nil
+}

--- a/internal/images/check.go
+++ b/internal/images/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"regexp"
 	"sort"
+	"sync"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gcstr/dockform/internal/registry"
@@ -14,23 +15,45 @@ import (
 //
 // Errors for individual images are captured in ImageStatus.Error so that a
 // single failing image does not abort the entire check.
-func Check(ctx context.Context, inputs []CheckInput, reg registry.Registry, localDigestFn LocalDigestFunc) ([]ImageStatus, error) {
-	var results []ImageStatus
+//
+// When sequential is false (the default), all images are checked concurrently.
+func Check(ctx context.Context, inputs []CheckInput, reg registry.Registry, localDigestFn LocalDigestFunc, sequential bool) ([]ImageStatus, error) {
+	// Flatten all (input, svcName) pairs first so we can preserve order.
+	type work struct {
+		input   CheckInput
+		svcName string
+	}
 
+	var jobs []work
 	for _, input := range inputs {
-		// Sort service names for deterministic output.
 		svcNames := make([]string, 0, len(input.Services))
 		for name := range input.Services {
 			svcNames = append(svcNames, name)
 		}
 		sort.Strings(svcNames)
-
 		for _, svcName := range svcNames {
-			imageStr := input.Services[svcName]
-			status := checkImage(ctx, input.StackKey, svcName, imageStr, input.TagPattern, reg, localDigestFn)
-			results = append(results, status)
+			jobs = append(jobs, work{input, svcName})
 		}
 	}
+
+	results := make([]ImageStatus, len(jobs))
+
+	if sequential {
+		for i, j := range jobs {
+			results[i] = checkImage(ctx, j.input.StackKey, j.svcName, j.input.Services[j.svcName], j.input.TagPattern, reg, localDigestFn)
+		}
+		return results, nil
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(jobs))
+	for i, j := range jobs {
+		go func(idx int, job work) {
+			defer wg.Done()
+			results[idx] = checkImage(ctx, job.input.StackKey, job.svcName, job.input.Services[job.svcName], job.input.TagPattern, reg, localDigestFn)
+		}(i, j)
+	}
+	wg.Wait()
 
 	return results, nil
 }

--- a/internal/images/check.go
+++ b/internal/images/check.go
@@ -67,6 +67,8 @@ func checkImage(
 		return status
 	}
 
+	status.LocalDigest = localDigest
+	status.RemoteDigest = remoteDigest
 	status.DigestStale = remoteDigest != localDigest
 
 	// Tag comparison (only when a pattern is configured).

--- a/internal/images/check.go
+++ b/internal/images/check.go
@@ -76,7 +76,7 @@ func checkImage(
 		return status
 	}
 
-	localDigest, err := localDigestFn(ctx, imageStr)
+	localDigest, err := localDigestFn(ctx, stackKey, imageStr)
 	if err != nil {
 		status.Error = err.Error()
 		return status

--- a/internal/images/check.go
+++ b/internal/images/check.go
@@ -67,8 +67,6 @@ func checkImage(
 		return status
 	}
 
-	status.LocalDigest = localDigest
-	status.RemoteDigest = remoteDigest
 	status.DigestStale = remoteDigest != localDigest
 
 	// Tag comparison (only when a pattern is configured).

--- a/internal/images/check.go
+++ b/internal/images/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"regexp"
 	"sort"
+	"sync"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gcstr/dockform/internal/registry"
@@ -14,23 +15,37 @@ import (
 //
 // Errors for individual images are captured in ImageStatus.Error so that a
 // single failing image does not abort the entire check.
+// All images are checked concurrently; output order matches input order.
 func Check(ctx context.Context, inputs []CheckInput, reg registry.Registry, localDigestFn LocalDigestFunc) ([]ImageStatus, error) {
-	var results []ImageStatus
+	type job struct {
+		input   CheckInput
+		svcName string
+	}
 
+	// Flatten into an ordered slice so results can be written at fixed indices.
+	var jobs []job
 	for _, input := range inputs {
-		// Sort service names for deterministic output.
 		svcNames := make([]string, 0, len(input.Services))
 		for name := range input.Services {
 			svcNames = append(svcNames, name)
 		}
 		sort.Strings(svcNames)
-
 		for _, svcName := range svcNames {
-			imageStr := input.Services[svcName]
-			status := checkImage(ctx, input.StackKey, svcName, imageStr, input.TagPattern, reg, localDigestFn)
-			results = append(results, status)
+			jobs = append(jobs, job{input, svcName})
 		}
 	}
+
+	results := make([]ImageStatus, len(jobs))
+
+	var wg sync.WaitGroup
+	wg.Add(len(jobs))
+	for i, j := range jobs {
+		go func(idx int, j job) {
+			defer wg.Done()
+			results[idx] = checkImage(ctx, j.input.StackKey, j.svcName, j.input.Services[j.svcName], j.input.TagPattern, reg, localDigestFn)
+		}(i, j)
+	}
+	wg.Wait()
 
 	return results, nil
 }

--- a/internal/images/check_test.go
+++ b/internal/images/check_test.go
@@ -79,7 +79,7 @@ func TestCheck_DigestMatch(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestCheck_DigestMismatch(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestCheck_TagPatternNewerVersions(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestCheck_TagPatternNoNewerVersions(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestCheck_CurrentTagNotSemver(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestCheck_TagPatternFilters(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestCheck_ImageParseError(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -311,7 +311,7 @@ func TestCheck_RegistryError(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestCheck_MultipleStacksMixedResults(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestCheck_LocalDigestError(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestCheck_ListTagsError(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn)
+	results, err := Check(context.Background(), inputs, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -447,7 +447,7 @@ func TestCheck_EmptyInputs(t *testing.T) {
 	reg := newMockRegistry()
 	localFn := mockLocalDigest(map[string]string{})
 
-	results, err := Check(context.Background(), nil, reg, localFn)
+	results, err := Check(context.Background(), nil, reg, localFn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/images/check_test.go
+++ b/internal/images/check_test.go
@@ -79,7 +79,7 @@ func TestCheck_DigestMatch(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestCheck_DigestMismatch(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestCheck_TagPatternNewerVersions(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestCheck_TagPatternNoNewerVersions(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestCheck_CurrentTagNotSemver(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestCheck_TagPatternFilters(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestCheck_ImageParseError(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -311,7 +311,7 @@ func TestCheck_RegistryError(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestCheck_MultipleStacksMixedResults(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestCheck_LocalDigestError(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestCheck_ListTagsError(t *testing.T) {
 		},
 	}
 
-	results, err := Check(context.Background(), inputs, reg, localFn, false)
+	results, err := Check(context.Background(), inputs, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -447,7 +447,7 @@ func TestCheck_EmptyInputs(t *testing.T) {
 	reg := newMockRegistry()
 	localFn := mockLocalDigest(map[string]string{})
 
-	results, err := Check(context.Background(), nil, reg, localFn, false)
+	results, err := Check(context.Background(), nil, reg, localFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/images/check_test.go
+++ b/internal/images/check_test.go
@@ -1,0 +1,457 @@
+package images
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gcstr/dockform/internal/registry"
+)
+
+// mockRegistry implements registry.Registry for testing.
+type mockRegistry struct {
+	tags    map[string][]string          // fullName -> tags
+	digests map[string]map[string]string // fullName -> tag -> digest
+	listErr map[string]error             // fullName -> error
+	getErr  map[string]error             // "fullName:tag" -> error
+}
+
+func newMockRegistry() *mockRegistry {
+	return &mockRegistry{
+		tags:    make(map[string][]string),
+		digests: make(map[string]map[string]string),
+		listErr: make(map[string]error),
+		getErr:  make(map[string]error),
+	}
+}
+
+func (m *mockRegistry) ListTags(_ context.Context, image registry.ImageRef) ([]string, error) {
+	name := image.FullName()
+	if err, ok := m.listErr[name]; ok {
+		return nil, err
+	}
+	return m.tags[name], nil
+}
+
+func (m *mockRegistry) GetRemoteDigest(_ context.Context, image registry.ImageRef, tag string) (string, error) {
+	name := image.FullName()
+	key := name + ":" + tag
+	if err, ok := m.getErr[key]; ok {
+		return "", err
+	}
+	if tagMap, ok := m.digests[name]; ok {
+		if d, ok := tagMap[tag]; ok {
+			return d, nil
+		}
+	}
+	return "", fmt.Errorf("digest not found for %s:%s", name, tag)
+}
+
+func (m *mockRegistry) setDigest(fullName, tag, digest string) {
+	if m.digests[fullName] == nil {
+		m.digests[fullName] = make(map[string]string)
+	}
+	m.digests[fullName][tag] = digest
+}
+
+// mockLocalDigest returns a LocalDigestFunc backed by a simple map.
+func mockLocalDigest(digests map[string]string) LocalDigestFunc {
+	return func(_ context.Context, imageRef string) (string, error) {
+		if d, ok := digests[imageRef]; ok {
+			return d, nil
+		}
+		return "", fmt.Errorf("local digest not found for %s", imageRef)
+	}
+}
+
+func TestCheck_DigestMatch(t *testing.T) {
+	reg := newMockRegistry()
+	reg.setDigest("library/nginx", "1.25", "sha256:abc123")
+
+	localFn := mockLocalDigest(map[string]string{
+		"nginx:1.25": "sha256:abc123",
+	})
+
+	inputs := []CheckInput{
+		{
+			StackKey: "ctx/web",
+			Services: map[string]string{"web": "nginx:1.25"},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.DigestStale {
+		t.Error("expected DigestStale=false")
+	}
+	if r.CurrentTag != "1.25" {
+		t.Errorf("expected CurrentTag=1.25, got %s", r.CurrentTag)
+	}
+	if r.Error != "" {
+		t.Errorf("expected no error, got %s", r.Error)
+	}
+}
+
+func TestCheck_DigestMismatch(t *testing.T) {
+	reg := newMockRegistry()
+	reg.setDigest("library/nginx", "1.25", "sha256:remote999")
+
+	localFn := mockLocalDigest(map[string]string{
+		"nginx:1.25": "sha256:local111",
+	})
+
+	inputs := []CheckInput{
+		{
+			StackKey: "ctx/web",
+			Services: map[string]string{"web": "nginx:1.25"},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := results[0]
+	if !r.DigestStale {
+		t.Error("expected DigestStale=true")
+	}
+}
+
+func TestCheck_TagPatternNewerVersions(t *testing.T) {
+	reg := newMockRegistry()
+	reg.setDigest("library/nginx", "1.25.0", "sha256:abc")
+	reg.tags["library/nginx"] = []string{"1.24.0", "1.25.0", "1.26.0", "1.27.0", "2.0.0", "latest"}
+
+	localFn := mockLocalDigest(map[string]string{
+		"nginx:1.25.0": "sha256:abc",
+	})
+
+	inputs := []CheckInput{
+		{
+			StackKey:   "ctx/web",
+			TagPattern: `^\d+\.\d+\.\d+$`,
+			Services:   map[string]string{"web": "nginx:1.25.0"},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := results[0]
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %s", r.Error)
+	}
+	if len(r.NewerTags) != 3 {
+		t.Fatalf("expected 3 newer tags, got %d: %v", len(r.NewerTags), r.NewerTags)
+	}
+	// Should be sorted descending.
+	expected := []string{"2.0.0", "1.27.0", "1.26.0"}
+	for i, tag := range expected {
+		if r.NewerTags[i] != tag {
+			t.Errorf("NewerTags[%d] = %s, want %s", i, r.NewerTags[i], tag)
+		}
+	}
+}
+
+func TestCheck_TagPatternNoNewerVersions(t *testing.T) {
+	reg := newMockRegistry()
+	reg.setDigest("library/nginx", "2.0.0", "sha256:abc")
+	reg.tags["library/nginx"] = []string{"1.24.0", "1.25.0", "2.0.0"}
+
+	localFn := mockLocalDigest(map[string]string{
+		"nginx:2.0.0": "sha256:abc",
+	})
+
+	inputs := []CheckInput{
+		{
+			StackKey:   "ctx/web",
+			TagPattern: `^\d+\.\d+\.\d+$`,
+			Services:   map[string]string{"web": "nginx:2.0.0"},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := results[0]
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %s", r.Error)
+	}
+	if len(r.NewerTags) != 0 {
+		t.Errorf("expected no newer tags, got %v", r.NewerTags)
+	}
+}
+
+func TestCheck_CurrentTagNotSemver(t *testing.T) {
+	reg := newMockRegistry()
+	reg.setDigest("library/nginx", "latest", "sha256:remote")
+	reg.tags["library/nginx"] = []string{"1.24.0", "1.25.0", "latest"}
+
+	localFn := mockLocalDigest(map[string]string{
+		"nginx:latest": "sha256:local",
+	})
+
+	inputs := []CheckInput{
+		{
+			StackKey:   "ctx/web",
+			TagPattern: `^\d+\.\d+\.\d+$`,
+			Services:   map[string]string{"web": "nginx:latest"},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := results[0]
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %s", r.Error)
+	}
+	// Should fall back to digest-only: no newer tags returned.
+	if len(r.NewerTags) != 0 {
+		t.Errorf("expected no newer tags for non-semver tag, got %v", r.NewerTags)
+	}
+	if !r.DigestStale {
+		t.Error("expected DigestStale=true")
+	}
+}
+
+func TestCheck_TagPatternFilters(t *testing.T) {
+	reg := newMockRegistry()
+	reg.setDigest("library/nginx", "1.25.0", "sha256:abc")
+	reg.tags["library/nginx"] = []string{
+		"1.24.0", "1.25.0", "1.26.0",
+		"1.26.0-alpine", "1.27.0-alpine", // Should be excluded by pattern
+		"2.0.0",
+	}
+
+	localFn := mockLocalDigest(map[string]string{
+		"nginx:1.25.0": "sha256:abc",
+	})
+
+	inputs := []CheckInput{
+		{
+			StackKey:   "ctx/web",
+			TagPattern: `^\d+\.\d+\.\d+$`, // Strict semver only, no suffixes
+			Services:   map[string]string{"web": "nginx:1.25.0"},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := results[0]
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %s", r.Error)
+	}
+	// Only strict semver tags newer than 1.25.0: 1.26.0, 2.0.0
+	expected := []string{"2.0.0", "1.26.0"}
+	if len(r.NewerTags) != len(expected) {
+		t.Fatalf("expected %d newer tags, got %d: %v", len(expected), len(r.NewerTags), r.NewerTags)
+	}
+	for i, tag := range expected {
+		if r.NewerTags[i] != tag {
+			t.Errorf("NewerTags[%d] = %s, want %s", i, r.NewerTags[i], tag)
+		}
+	}
+}
+
+func TestCheck_ImageParseError(t *testing.T) {
+	reg := newMockRegistry()
+	localFn := mockLocalDigest(map[string]string{})
+
+	inputs := []CheckInput{
+		{
+			StackKey: "ctx/web",
+			Services: map[string]string{"bad": ""},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := results[0]
+	if r.Error == "" {
+		t.Error("expected error for empty image ref")
+	}
+}
+
+func TestCheck_RegistryError(t *testing.T) {
+	reg := newMockRegistry()
+	reg.getErr["library/nginx:1.25"] = fmt.Errorf("registry unavailable")
+
+	localFn := mockLocalDigest(map[string]string{
+		"nginx:1.25": "sha256:abc",
+	})
+
+	inputs := []CheckInput{
+		{
+			StackKey: "ctx/web",
+			Services: map[string]string{
+				"web":   "nginx:1.25",
+				"proxy": "nginx:1.25",
+			},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both services reference the same failing image; both should have errors.
+	for _, r := range results {
+		if r.Error == "" {
+			t.Errorf("expected error for service %s", r.Service)
+		}
+	}
+}
+
+func TestCheck_MultipleStacksMixedResults(t *testing.T) {
+	reg := newMockRegistry()
+	reg.setDigest("library/nginx", "1.25.0", "sha256:remote1")
+	reg.setDigest("library/redis", "7.0", "sha256:same")
+	reg.tags["library/nginx"] = []string{"1.25.0", "1.26.0"}
+
+	localFn := mockLocalDigest(map[string]string{
+		"nginx:1.25.0": "sha256:local1",
+		"redis:7.0":    "sha256:same",
+	})
+
+	inputs := []CheckInput{
+		{
+			StackKey:   "ctx1/web",
+			TagPattern: `^\d+\.\d+\.\d+$`,
+			Services:   map[string]string{"web": "nginx:1.25.0"},
+		},
+		{
+			StackKey: "ctx2/cache",
+			Services: map[string]string{"cache": "redis:7.0"},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// First result: nginx - stale with newer tags.
+	nginx := results[0]
+	if nginx.Stack != "ctx1/web" {
+		t.Errorf("expected stack ctx1/web, got %s", nginx.Stack)
+	}
+	if !nginx.DigestStale {
+		t.Error("expected nginx DigestStale=true")
+	}
+	if len(nginx.NewerTags) != 1 || nginx.NewerTags[0] != "1.26.0" {
+		t.Errorf("expected newer tags [1.26.0], got %v", nginx.NewerTags)
+	}
+
+	// Second result: redis - up to date.
+	redis := results[1]
+	if redis.Stack != "ctx2/cache" {
+		t.Errorf("expected stack ctx2/cache, got %s", redis.Stack)
+	}
+	if redis.DigestStale {
+		t.Error("expected redis DigestStale=false")
+	}
+	if len(redis.NewerTags) != 0 {
+		t.Errorf("expected no newer tags for redis, got %v", redis.NewerTags)
+	}
+}
+
+func TestCheck_LocalDigestError(t *testing.T) {
+	reg := newMockRegistry()
+	reg.setDigest("library/nginx", "1.25", "sha256:remote")
+
+	localFn := func(_ context.Context, _ string) (string, error) {
+		return "", fmt.Errorf("image not pulled locally")
+	}
+
+	inputs := []CheckInput{
+		{
+			StackKey: "ctx/web",
+			Services: map[string]string{"web": "nginx:1.25"},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := results[0]
+	if r.Error == "" {
+		t.Error("expected error for local digest failure")
+	}
+	if r.DigestStale {
+		t.Error("DigestStale should be false when check errored")
+	}
+}
+
+func TestCheck_ListTagsError(t *testing.T) {
+	reg := newMockRegistry()
+	reg.setDigest("library/nginx", "1.25.0", "sha256:abc")
+	reg.listErr["library/nginx"] = fmt.Errorf("rate limited")
+
+	localFn := mockLocalDigest(map[string]string{
+		"nginx:1.25.0": "sha256:abc",
+	})
+
+	inputs := []CheckInput{
+		{
+			StackKey:   "ctx/web",
+			TagPattern: `^\d+\.\d+\.\d+$`,
+			Services:   map[string]string{"web": "nginx:1.25.0"},
+		},
+	}
+
+	results, err := Check(context.Background(), inputs, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := results[0]
+	if r.Error == "" {
+		t.Error("expected error when ListTags fails")
+	}
+	// Digest comparison should still have run before the tag error.
+	// Since digests match, DigestStale should be false.
+	if r.DigestStale {
+		t.Error("expected DigestStale=false since digests match")
+	}
+}
+
+func TestCheck_EmptyInputs(t *testing.T) {
+	reg := newMockRegistry()
+	localFn := mockLocalDigest(map[string]string{})
+
+	results, err := Check(context.Background(), nil, reg, localFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %d", len(results))
+	}
+}

--- a/internal/images/check_test.go
+++ b/internal/images/check_test.go
@@ -56,7 +56,7 @@ func (m *mockRegistry) setDigest(fullName, tag, digest string) {
 
 // mockLocalDigest returns a LocalDigestFunc backed by a simple map.
 func mockLocalDigest(digests map[string]string) LocalDigestFunc {
-	return func(_ context.Context, imageRef string) (string, error) {
+	return func(_ context.Context, _ string, imageRef string) (string, error) {
 		if d, ok := digests[imageRef]; ok {
 			return d, nil
 		}
@@ -385,7 +385,7 @@ func TestCheck_LocalDigestError(t *testing.T) {
 	reg := newMockRegistry()
 	reg.setDigest("library/nginx", "1.25", "sha256:remote")
 
-	localFn := func(_ context.Context, _ string) (string, error) {
+	localFn := func(_ context.Context, _ string, _ string) (string, error) {
 		return "", fmt.Errorf("image not pulled locally")
 	}
 

--- a/internal/images/types.go
+++ b/internal/images/types.go
@@ -20,9 +20,10 @@ type CheckInput struct {
 	Services   map[string]string // service name -> image reference (from ComposeConfigFull)
 }
 
-// LocalDigestFunc returns the local digest for an image reference.
+// LocalDigestFunc returns the local digest for an image reference on the
+// Docker daemon associated with the given stack.
 // This is injected to avoid coupling to the docker CLI directly.
-type LocalDigestFunc func(ctx context.Context, imageRef string) (string, error)
+type LocalDigestFunc func(ctx context.Context, stackKey, imageRef string) (string, error)
 
 // FileChange represents a tag rewrite in a compose file.
 type FileChange struct {

--- a/internal/images/types.go
+++ b/internal/images/types.go
@@ -8,9 +8,11 @@ type ImageStatus struct {
 	Service     string   // Service name within the compose file
 	Image       string   // Full image reference as written in compose
 	CurrentTag  string   // Current tag
-	DigestStale bool     // True if remote digest differs from local
-	NewerTags   []string // Newer semver tags (empty if no tag_pattern or no newer tags)
-	Error       string   // Non-empty if check failed for this image
+	DigestStale  bool     // True if remote digest differs from local
+	LocalDigest  string   // Local repo digest (sha256:...), empty if not pulled
+	RemoteDigest string   // Remote manifest digest (sha256:...)
+	NewerTags    []string // Newer semver tags (empty if no tag_pattern or no newer tags)
+	Error        string   // Non-empty if check failed for this image
 }
 
 // CheckInput bundles everything needed to check images for a stack.

--- a/internal/images/types.go
+++ b/internal/images/types.go
@@ -8,11 +8,9 @@ type ImageStatus struct {
 	Service     string   // Service name within the compose file
 	Image       string   // Full image reference as written in compose
 	CurrentTag  string   // Current tag
-	DigestStale  bool     // True if remote digest differs from local
-	LocalDigest  string   // Local repo digest (sha256:...), empty if not pulled
-	RemoteDigest string   // Remote manifest digest (sha256:...)
-	NewerTags    []string // Newer semver tags (empty if no tag_pattern or no newer tags)
-	Error        string   // Non-empty if check failed for this image
+	DigestStale bool     // True if remote digest differs from local
+	NewerTags   []string // Newer semver tags (empty if no tag_pattern or no newer tags)
+	Error       string   // Non-empty if check failed for this image
 }
 
 // CheckInput bundles everything needed to check images for a stack.

--- a/internal/images/types.go
+++ b/internal/images/types.go
@@ -1,0 +1,25 @@
+package images
+
+import "context"
+
+// ImageStatus represents the check result for a single image.
+type ImageStatus struct {
+	Stack       string   // Stack key (e.g., "hetzner/traefik")
+	Service     string   // Service name within the compose file
+	Image       string   // Full image reference as written in compose
+	CurrentTag  string   // Current tag
+	DigestStale bool     // True if remote digest differs from local
+	NewerTags   []string // Newer semver tags (empty if no tag_pattern or no newer tags)
+	Error       string   // Non-empty if check failed for this image
+}
+
+// CheckInput bundles everything needed to check images for a stack.
+type CheckInput struct {
+	StackKey   string            // Stack key (e.g., "hetzner/traefik")
+	TagPattern string            // From stack.Images.TagPattern, empty means digest-only
+	Services   map[string]string // service name -> image reference (from ComposeConfigFull)
+}
+
+// LocalDigestFunc returns the local digest for an image reference.
+// This is injected to avoid coupling to the docker CLI directly.
+type LocalDigestFunc func(ctx context.Context, imageRef string) (string, error)

--- a/internal/images/types.go
+++ b/internal/images/types.go
@@ -23,3 +23,13 @@ type CheckInput struct {
 // LocalDigestFunc returns the local digest for an image reference.
 // This is injected to avoid coupling to the docker CLI directly.
 type LocalDigestFunc func(ctx context.Context, imageRef string) (string, error)
+
+// FileChange represents a tag rewrite in a compose file.
+type FileChange struct {
+	StackKey string // Stack key (e.g., "hetzner/traefik")
+	Service  string // Service name
+	File     string // Path to compose file that was modified
+	Image    string // Image name (without tag)
+	OldTag   string // Previous tag
+	NewTag   string // New tag written
+}

--- a/internal/images/upgrade.go
+++ b/internal/images/upgrade.go
@@ -1,0 +1,89 @@
+package images
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Upgrade takes check results and a map of stack keys to compose file paths,
+// rewrites the image tags in the compose files, and returns what changed.
+//
+// Only results with non-empty NewerTags and no Error are processed.
+// The new tag applied is NewerTags[0] (the newest available).
+// File content is rewritten only when a change is detected.
+func Upgrade(results []ImageStatus, stackFiles map[string][]string) ([]FileChange, error) {
+	var changes []FileChange
+
+	for _, result := range results {
+		if result.Error != "" || len(result.NewerTags) == 0 {
+			continue
+		}
+
+		files, ok := stackFiles[result.Stack]
+		if !ok || len(files) == 0 {
+			continue
+		}
+
+		newTag := result.NewerTags[0]
+		oldImage := result.Image // full reference as written, e.g. "traefik:v3.0.1"
+
+		// Derive image name without the tag for the FileChange record.
+		imageName := oldImage
+		if idx := strings.LastIndex(oldImage, ":"); idx != -1 {
+			imageName = oldImage[:idx]
+		}
+
+		newImage := imageName + ":" + newTag
+
+		for _, filePath := range files {
+			changed, err := rewriteImageInFile(filePath, oldImage, newImage)
+			if err != nil {
+				return nil, fmt.Errorf("upgrade: rewriting %s: %w", filePath, err)
+			}
+			if changed {
+				changes = append(changes, FileChange{
+					StackKey: result.Stack,
+					Service:  result.Service,
+					File:     filePath,
+					Image:    imageName,
+					OldTag:   result.CurrentTag,
+					NewTag:   newTag,
+				})
+			}
+		}
+	}
+
+	return changes, nil
+}
+
+// rewriteImageInFile replaces all occurrences of oldImage with newImage in the
+// file at path using simple string substitution (no YAML parsing). The file is
+// written back only when at least one replacement was made.
+//
+// Both unquoted and double-quoted variants are handled:
+//
+//	image: traefik:v3.0.1
+//	image: "traefik:v3.0.1"
+func rewriteImageInFile(path, oldImage, newImage string) (changed bool, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	content := string(data)
+	original := content
+
+	// Replace unquoted form.
+	content = strings.ReplaceAll(content, oldImage, newImage)
+
+	if content == original {
+		return false, nil
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/internal/images/upgrade_test.go
+++ b/internal/images/upgrade_test.go
@@ -1,0 +1,395 @@
+package images
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeComposeFile creates a compose file with the given content inside dir.
+func writeComposeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeComposeFile: %v", err)
+	}
+	return path
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readFile %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func TestUpgrade_SingleImageRewrite(t *testing.T) {
+	dir := t.TempDir()
+	content := `services:
+  proxy:
+    image: traefik:v3.0.1
+    ports:
+      - "80:80"
+`
+	path := writeComposeFile(t, dir, "docker-compose.yml", content)
+
+	results := []ImageStatus{
+		{
+			Stack:      "hetzner/traefik",
+			Service:    "proxy",
+			Image:      "traefik:v3.0.1",
+			CurrentTag: "v3.0.1",
+			NewerTags:  []string{"v3.2.1", "v3.1.0"},
+		},
+	}
+	stackFiles := map[string][]string{
+		"hetzner/traefik": {path},
+	}
+
+	changes, err := Upgrade(results, stackFiles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+
+	c := changes[0]
+	if c.StackKey != "hetzner/traefik" {
+		t.Errorf("StackKey = %q, want %q", c.StackKey, "hetzner/traefik")
+	}
+	if c.Service != "proxy" {
+		t.Errorf("Service = %q, want %q", c.Service, "proxy")
+	}
+	if c.Image != "traefik" {
+		t.Errorf("Image = %q, want %q", c.Image, "traefik")
+	}
+	if c.OldTag != "v3.0.1" {
+		t.Errorf("OldTag = %q, want %q", c.OldTag, "v3.0.1")
+	}
+	if c.NewTag != "v3.2.1" {
+		t.Errorf("NewTag = %q, want %q", c.NewTag, "v3.2.1")
+	}
+	if c.File != path {
+		t.Errorf("File = %q, want %q", c.File, path)
+	}
+
+	got := readFile(t, path)
+	if want := `services:
+  proxy:
+    image: traefik:v3.2.1
+    ports:
+      - "80:80"
+`; got != want {
+		t.Errorf("file content mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestUpgrade_MultipleImagesInSameFile(t *testing.T) {
+	dir := t.TempDir()
+	content := `services:
+  proxy:
+    image: traefik:v3.0.1
+  app:
+    image: myapp:1.0.0
+`
+	path := writeComposeFile(t, dir, "docker-compose.yml", content)
+
+	results := []ImageStatus{
+		{
+			Stack:      "mystack",
+			Service:    "proxy",
+			Image:      "traefik:v3.0.1",
+			CurrentTag: "v3.0.1",
+			NewerTags:  []string{"v3.2.1"},
+		},
+		{
+			Stack:      "mystack",
+			Service:    "app",
+			Image:      "myapp:1.0.0",
+			CurrentTag: "1.0.0",
+			NewerTags:  []string{"1.2.0"},
+		},
+	}
+	stackFiles := map[string][]string{
+		"mystack": {path},
+	}
+
+	changes, err := Upgrade(results, stackFiles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(changes) != 2 {
+		t.Fatalf("expected 2 changes, got %d", len(changes))
+	}
+
+	got := readFile(t, path)
+	if want := `services:
+  proxy:
+    image: traefik:v3.2.1
+  app:
+    image: myapp:1.2.0
+`; got != want {
+		t.Errorf("file content mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestUpgrade_NoQualifyingResults_EmptyNewerTags(t *testing.T) {
+	dir := t.TempDir()
+	content := `services:
+  proxy:
+    image: traefik:v3.0.1
+`
+	path := writeComposeFile(t, dir, "docker-compose.yml", content)
+
+	results := []ImageStatus{
+		{
+			Stack:      "mystack",
+			Service:    "proxy",
+			Image:      "traefik:v3.0.1",
+			CurrentTag: "v3.0.1",
+			NewerTags:  []string{}, // empty — no upgrade available
+		},
+	}
+	stackFiles := map[string][]string{
+		"mystack": {path},
+	}
+
+	changes, err := Upgrade(results, stackFiles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected no changes, got %d", len(changes))
+	}
+
+	// File should be untouched.
+	got := readFile(t, path)
+	if got != content {
+		t.Errorf("file should be unchanged, got:\n%s", got)
+	}
+}
+
+func TestUpgrade_ResultsWithErrorsAreSkipped(t *testing.T) {
+	dir := t.TempDir()
+	content := `services:
+  proxy:
+    image: traefik:v3.0.1
+`
+	path := writeComposeFile(t, dir, "docker-compose.yml", content)
+
+	results := []ImageStatus{
+		{
+			Stack:      "mystack",
+			Service:    "proxy",
+			Image:      "traefik:v3.0.1",
+			CurrentTag: "v3.0.1",
+			NewerTags:  []string{"v3.2.1"},
+			Error:      "registry unavailable",
+		},
+	}
+	stackFiles := map[string][]string{
+		"mystack": {path},
+	}
+
+	changes, err := Upgrade(results, stackFiles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected no changes for errored result, got %d", len(changes))
+	}
+
+	// File should be untouched.
+	got := readFile(t, path)
+	if got != content {
+		t.Errorf("file should be unchanged, got:\n%s", got)
+	}
+}
+
+func TestUpgrade_FileNotFound(t *testing.T) {
+	results := []ImageStatus{
+		{
+			Stack:      "mystack",
+			Service:    "proxy",
+			Image:      "traefik:v3.0.1",
+			CurrentTag: "v3.0.1",
+			NewerTags:  []string{"v3.2.1"},
+		},
+	}
+	stackFiles := map[string][]string{
+		"mystack": {"/nonexistent/path/docker-compose.yml"},
+	}
+
+	_, err := Upgrade(results, stackFiles)
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestUpgrade_OriginalFormattingAndCommentsPreserved(t *testing.T) {
+	dir := t.TempDir()
+	content := `# Managed by dockform
+version: "3.9"
+
+services:
+  # Reverse proxy
+  proxy:
+    image: traefik:v3.0.1
+    # Important: keep port 80 open
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+`
+	path := writeComposeFile(t, dir, "docker-compose.yml", content)
+
+	results := []ImageStatus{
+		{
+			Stack:      "infra",
+			Service:    "proxy",
+			Image:      "traefik:v3.0.1",
+			CurrentTag: "v3.0.1",
+			NewerTags:  []string{"v3.2.1"},
+		},
+	}
+	stackFiles := map[string][]string{
+		"infra": {path},
+	}
+
+	changes, err := Upgrade(results, stackFiles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+
+	got := readFile(t, path)
+	want := `# Managed by dockform
+version: "3.9"
+
+services:
+  # Reverse proxy
+  proxy:
+    image: traefik:v3.2.1
+    # Important: keep port 80 open
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+`
+	if got != want {
+		t.Errorf("file content mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestUpgrade_QuotedImageIsReplaced(t *testing.T) {
+	dir := t.TempDir()
+	content := `services:
+  proxy:
+    image: "traefik:v3.0.1"
+`
+	path := writeComposeFile(t, dir, "docker-compose.yml", content)
+
+	results := []ImageStatus{
+		{
+			Stack:      "mystack",
+			Service:    "proxy",
+			Image:      "traefik:v3.0.1",
+			CurrentTag: "v3.0.1",
+			NewerTags:  []string{"v3.2.1"},
+		},
+	}
+	stackFiles := map[string][]string{
+		"mystack": {path},
+	}
+
+	changes, err := Upgrade(results, stackFiles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+
+	got := readFile(t, path)
+	want := `services:
+  proxy:
+    image: "traefik:v3.2.1"
+`
+	if got != want {
+		t.Errorf("file content mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestUpgrade_StackNotInStackFiles(t *testing.T) {
+	dir := t.TempDir()
+	content := `services:
+  proxy:
+    image: traefik:v3.0.1
+`
+	path := writeComposeFile(t, dir, "docker-compose.yml", content)
+
+	results := []ImageStatus{
+		{
+			Stack:      "other-stack",
+			Service:    "proxy",
+			Image:      "traefik:v3.0.1",
+			CurrentTag: "v3.0.1",
+			NewerTags:  []string{"v3.2.1"},
+		},
+	}
+	// stackFiles does not contain "other-stack"
+	stackFiles := map[string][]string{
+		"mystack": {path},
+	}
+
+	changes, err := Upgrade(results, stackFiles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected no changes when stack not in stackFiles, got %d", len(changes))
+	}
+}
+
+func TestUpgrade_ImageNotPresentInFile(t *testing.T) {
+	dir := t.TempDir()
+	content := `services:
+  proxy:
+    image: nginx:1.25
+`
+	path := writeComposeFile(t, dir, "docker-compose.yml", content)
+
+	results := []ImageStatus{
+		{
+			Stack:      "mystack",
+			Service:    "proxy",
+			Image:      "traefik:v3.0.1", // not in the file
+			CurrentTag: "v3.0.1",
+			NewerTags:  []string{"v3.2.1"},
+		},
+	}
+	stackFiles := map[string][]string{
+		"mystack": {path},
+	}
+
+	changes, err := Upgrade(results, stackFiles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No match → no changes, file untouched.
+	if len(changes) != 0 {
+		t.Errorf("expected no changes, got %d", len(changes))
+	}
+
+	got := readFile(t, path)
+	if got != content {
+		t.Errorf("file should be unchanged")
+	}
+}

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -308,6 +308,9 @@ func (c *Config) GetAllStacks() map[string]Stack {
 			if v.Project != nil {
 				merged.Project = v.Project
 			}
+			if v.Images != nil {
+				merged.Images = v.Images
+			}
 			result[k] = merged
 		} else {
 			// No discovered stack: use explicit stack as fallback

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -90,6 +90,11 @@ func (d DiscoveryConfig) GetVolumesDir() string {
 	return d.VolumesDir
 }
 
+// ImagesConfig configures image update checking for a stack.
+type ImagesConfig struct {
+	TagPattern string `yaml:"tag_pattern"`
+}
+
 // Stack defines a Docker Compose stack to manage.
 // Stacks are discovered automatically from context directories.
 // The stacks: block can augment discovered stacks or define explicit stacks.
@@ -100,11 +105,12 @@ type Stack struct {
 	EnvFile []string `yaml:"env-file"` // Env files
 
 	// Override fields (typically set in stacks: block to augment discovered stacks)
-	Profiles    []string                `yaml:"profiles"`    // Compose profiles to activate
-	Environment *Environment            `yaml:"environment"` // Additional environment config
-	Secrets     *Secrets                `yaml:"secrets"`     // Additional SOPS secrets
-	Project     *Project                `yaml:"project"`     // Compose project name override
-	Filesets    map[string]FilesetSpec  `yaml:"filesets"`    // Fileset overrides/declarations
+	Profiles    []string               `yaml:"profiles"`    // Compose profiles to activate
+	Environment *Environment           `yaml:"environment"` // Additional environment config
+	Secrets     *Secrets               `yaml:"secrets"`     // Additional SOPS secrets
+	Project     *Project               `yaml:"project"`     // Compose project name override
+	Filesets    map[string]FilesetSpec `yaml:"filesets"`    // Fileset overrides/declarations
+	Images      *ImagesConfig          `yaml:"images"`      // Image update checking config
 
 	// Computed fields
 	Context     string   `yaml:"-"` // Which context this belongs to (from key prefix)

--- a/internal/manifest/validation_test.go
+++ b/internal/manifest/validation_test.go
@@ -699,6 +699,35 @@ func TestGetAllStacks(t *testing.T) {
 	}
 }
 
+func TestGetAllStacks_ImagesMerged(t *testing.T) {
+	cfg := Config{
+		Stacks: map[string]Stack{
+			"default/web": {
+				Images: &ImagesConfig{TagPattern: `^\d+\.\d+\.\d+$`},
+			},
+		},
+		DiscoveredStacks: map[string]Stack{
+			"default/web": {Root: "/discovered/web"},
+		},
+	}
+
+	all := cfg.GetAllStacks()
+	web, ok := all["default/web"]
+	if !ok {
+		t.Fatal("expected default/web in result")
+	}
+	if web.Images == nil {
+		t.Fatal("expected Images to be merged from explicit stack, got nil")
+	}
+	if web.Images.TagPattern != `^\d+\.\d+\.\d+$` {
+		t.Errorf("TagPattern: want %q, got %q", `^\d+\.\d+\.\d+$`, web.Images.TagPattern)
+	}
+	// Discovery still wins for core fields.
+	if web.Root != "/discovered/web" {
+		t.Errorf("Root: want /discovered/web, got %q", web.Root)
+	}
+}
+
 func TestGetStacksForDaemon(t *testing.T) {
 	cfg := Config{
 		Stacks: map[string]Stack{

--- a/internal/registry/auth.go
+++ b/internal/registry/auth.go
@@ -1,0 +1,228 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/gcstr/dockform/internal/apperr"
+)
+
+// tokenCache caches bearer tokens keyed by scope string.
+type tokenCache struct {
+	mu     sync.RWMutex
+	tokens map[string]string
+}
+
+func newTokenCache() *tokenCache {
+	return &tokenCache{tokens: make(map[string]string)}
+}
+
+func (c *tokenCache) get(scope string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	t, ok := c.tokens[scope]
+	return t, ok
+}
+
+func (c *tokenCache) set(scope string, token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tokens[scope] = token
+}
+
+// challenge represents a parsed WWW-Authenticate challenge.
+type challenge struct {
+	Realm   string
+	Service string
+	Scope   string
+}
+
+// parseChallenge parses the WWW-Authenticate header value.
+// Expected format: Bearer realm="...",service="...",scope="..."
+func parseChallenge(header string) (challenge, error) {
+	const op = "registry.parseChallenge"
+
+	header = strings.TrimSpace(header)
+	if !strings.HasPrefix(header, "Bearer ") {
+		return challenge{}, apperr.New(op, apperr.External, "unsupported auth scheme: %s", header)
+	}
+
+	header = strings.TrimPrefix(header, "Bearer ")
+	var ch challenge
+
+	for _, part := range splitParams(header) {
+		part = strings.TrimSpace(part)
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		value = strings.Trim(value, `"`)
+		switch key {
+		case "realm":
+			ch.Realm = value
+		case "service":
+			ch.Service = value
+		case "scope":
+			ch.Scope = value
+		}
+	}
+
+	if ch.Realm == "" {
+		return challenge{}, apperr.New(op, apperr.External, "missing realm in WWW-Authenticate header")
+	}
+
+	return ch, nil
+}
+
+// splitParams splits a comma-separated header value, respecting quoted strings.
+func splitParams(s string) []string {
+	var parts []string
+	var current strings.Builder
+	inQuote := false
+
+	for _, r := range s {
+		switch {
+		case r == '"':
+			inQuote = !inQuote
+			current.WriteRune(r)
+		case r == ',' && !inQuote:
+			parts = append(parts, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+
+	return parts
+}
+
+// tokenResponse is the JSON structure returned by token endpoints.
+type tokenResponse struct {
+	Token       string `json:"token"`
+	AccessToken string `json:"access_token"`
+}
+
+// fetchToken requests a bearer token from the auth realm.
+func fetchToken(ctx context.Context, client *http.Client, ch challenge) (string, error) {
+	const op = "registry.fetchToken"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ch.Realm, nil)
+	if err != nil {
+		return "", apperr.Wrap(op, apperr.Internal, err, "building token request")
+	}
+
+	q := req.URL.Query()
+	if ch.Service != "" {
+		q.Set("service", ch.Service)
+	}
+	if ch.Scope != "" {
+		q.Set("scope", ch.Scope)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", apperr.Wrap(op, apperr.Unavailable, err, "requesting token from %s", ch.Realm)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", apperr.New(op, apperr.External, "token endpoint returned %d", resp.StatusCode)
+	}
+
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return "", apperr.Wrap(op, apperr.External, err, "decoding token response")
+	}
+
+	token := tr.Token
+	if token == "" {
+		token = tr.AccessToken
+	}
+	if token == "" {
+		return "", apperr.New(op, apperr.External, "empty token in response from %s", ch.Realm)
+	}
+
+	return token, nil
+}
+
+// doWithAuth executes an HTTP request with automatic token-based authentication.
+// If the initial request returns 401, it parses the WWW-Authenticate challenge,
+// fetches a bearer token, and retries the request.
+func doWithAuth(ctx context.Context, client *http.Client, cache *tokenCache, req *http.Request) (*http.Response, error) {
+	const op = "registry.doWithAuth"
+
+	// Build a scope key from the request for cache lookup.
+	scopeKey := fmt.Sprintf("%s:%s", req.URL.Host, req.URL.Path)
+
+	// Try with cached token first.
+	if token, ok := cache.get(scopeKey); ok {
+		req2 := req.Clone(ctx)
+		req2.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req2)
+		if err != nil {
+			return nil, apperr.Wrap(op, apperr.Unavailable, err, "executing authenticated request")
+		}
+		if resp.StatusCode != http.StatusUnauthorized {
+			return resp, nil
+		}
+		_ = resp.Body.Close()
+		// Cached token is stale, fall through to re-auth.
+	}
+
+	// Try unauthenticated.
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, apperr.Wrap(op, apperr.Unavailable, err, "executing request to %s", req.URL.String())
+	}
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	_ = resp.Body.Close()
+
+	// Parse challenge and fetch token.
+	wwwAuth := resp.Header.Get("WWW-Authenticate")
+	if wwwAuth == "" {
+		return nil, apperr.New(op, apperr.External, "received 401 but no WWW-Authenticate header")
+	}
+
+	ch, err := parseChallenge(wwwAuth)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := fetchToken(ctx, client, ch)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the token using the challenge scope if available, otherwise use our key.
+	cacheKey := scopeKey
+	if ch.Scope != "" {
+		cacheKey = ch.Scope
+	}
+	cache.set(cacheKey, token)
+	// Also cache under scopeKey so subsequent requests to the same path hit cache.
+	if cacheKey != scopeKey {
+		cache.set(scopeKey, token)
+	}
+
+	// Retry with token.
+	req2 := req.Clone(ctx)
+	req2.Header.Set("Authorization", "Bearer "+token)
+	resp2, err := client.Do(req2)
+	if err != nil {
+		return nil, apperr.Wrap(op, apperr.Unavailable, err, "executing authenticated retry")
+	}
+
+	return resp2, nil
+}

--- a/internal/registry/oci.go
+++ b/internal/registry/oci.go
@@ -1,0 +1,149 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gcstr/dockform/internal/apperr"
+)
+
+// manifestAcceptHeader lists the media types the client accepts when querying manifests.
+const manifestAcceptHeader = "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json"
+
+// OCIClient implements Registry using the OCI Distribution Spec HTTP API.
+type OCIClient struct {
+	client *http.Client
+	cache  *tokenCache
+}
+
+// NewOCIClient creates a new OCI registry client with the given HTTP client.
+// If httpClient is nil, http.DefaultClient is used.
+func NewOCIClient(httpClient *http.Client) *OCIClient {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &OCIClient{
+		client: httpClient,
+		cache:  newTokenCache(),
+	}
+}
+
+// tagsResponse is the JSON structure returned by the /v2/{name}/tags/list endpoint.
+type tagsResponse struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+// ListTags returns all tags for an image from the remote registry.
+// It handles pagination via the Link header.
+func (c *OCIClient) ListTags(ctx context.Context, image ImageRef) ([]string, error) {
+	const op = "registry.ListTags"
+
+	baseURL := registryURL(image.Registry)
+	url := fmt.Sprintf("%s/v2/%s/tags/list", baseURL, image.FullName())
+
+	var allTags []string
+
+	for url != "" {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, apperr.Wrap(op, apperr.Internal, err, "building tags request")
+		}
+
+		resp, err := doWithAuth(ctx, c.client, c.cache, req)
+		if err != nil {
+			return nil, apperr.Wrap(op, apperr.Unavailable, err, "listing tags for %s", image.FullName())
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, apperr.New(op, apperr.NotFound, "repository not found: %s", image.FullName())
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, apperr.New(op, apperr.External, "unexpected status %d listing tags for %s", resp.StatusCode, image.FullName())
+		}
+
+		var tr tagsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+			return nil, apperr.Wrap(op, apperr.External, err, "decoding tags response for %s", image.FullName())
+		}
+
+		allTags = append(allTags, tr.Tags...)
+
+		// Check for pagination via Link header.
+		url = parseNextLink(resp.Header.Get("Link"), baseURL)
+	}
+
+	return allTags, nil
+}
+
+// GetRemoteDigest returns the digest of a specific tag from the remote registry.
+// It uses a HEAD request to the manifests endpoint and reads the Docker-Content-Digest header.
+func (c *OCIClient) GetRemoteDigest(ctx context.Context, image ImageRef, tag string) (string, error) {
+	const op = "registry.GetRemoteDigest"
+
+	if tag == "" {
+		return "", apperr.New(op, apperr.InvalidInput, "tag cannot be empty")
+	}
+
+	baseURL := registryURL(image.Registry)
+	url := fmt.Sprintf("%s/v2/%s/manifests/%s", baseURL, image.FullName(), tag)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return "", apperr.Wrap(op, apperr.Internal, err, "building manifest request")
+	}
+	req.Header.Set("Accept", manifestAcceptHeader)
+
+	resp, err := doWithAuth(ctx, c.client, c.cache, req)
+	if err != nil {
+		return "", apperr.Wrap(op, apperr.Unavailable, err, "fetching digest for %s:%s", image.FullName(), tag)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", apperr.New(op, apperr.NotFound, "tag not found: %s:%s", image.FullName(), tag)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", apperr.New(op, apperr.External, "unexpected status %d fetching digest for %s:%s", resp.StatusCode, image.FullName(), tag)
+	}
+
+	digest := resp.Header.Get("Docker-Content-Digest")
+	if digest == "" {
+		return "", apperr.New(op, apperr.External, "no Docker-Content-Digest header in response for %s:%s", image.FullName(), tag)
+	}
+
+	return digest, nil
+}
+
+// parseNextLink parses the Link header for pagination.
+// Format: </v2/name/tags/list?n=100&last=tag>; rel="next"
+func parseNextLink(header, baseURL string) string {
+	if header == "" {
+		return ""
+	}
+
+	for part := range strings.SplitSeq(header, ",") {
+		part = strings.TrimSpace(part)
+		if !strings.Contains(part, `rel="next"`) {
+			continue
+		}
+		// Extract URL between < and >
+		start := strings.Index(part, "<")
+		end := strings.Index(part, ">")
+		if start < 0 || end < 0 || end <= start {
+			continue
+		}
+		link := part[start+1 : end]
+		// If the link is relative, prepend the base URL.
+		if strings.HasPrefix(link, "/") {
+			return baseURL + link
+		}
+		return link
+	}
+
+	return ""
+}

--- a/internal/registry/oci.go
+++ b/internal/registry/oci.go
@@ -11,7 +11,8 @@ import (
 )
 
 // manifestAcceptHeader lists the media types the client accepts when querying manifests.
-const manifestAcceptHeader = "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json"
+// Includes OCI image index and Docker manifest list to support multi-arch images.
+const manifestAcceptHeader = "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json"
 
 // OCIClient implements Registry using the OCI Distribution Spec HTTP API.
 type OCIClient struct {

--- a/internal/registry/oci_test.go
+++ b/internal/registry/oci_test.go
@@ -1,0 +1,371 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gcstr/dockform/internal/apperr"
+)
+
+// newTestServer creates a registry mock server and returns the server plus
+// an OCIClient configured to talk to it.
+func newTestServer(handler http.Handler) (*httptest.Server, *OCIClient) {
+	srv := httptest.NewServer(handler)
+	client := NewOCIClient(srv.Client())
+	return srv, client
+}
+
+// imageForServer returns an ImageRef that points to the given test server.
+// It uses the full server URL (including scheme) as the Registry field,
+// which registryURL() passes through unchanged.
+func imageForServer(srv *httptest.Server, name string) ImageRef {
+	return ImageRef{
+		Registry:  srv.URL,
+		Namespace: "",
+		Name:      name,
+		Tag:       "latest",
+	}
+}
+
+func TestOCIClient_ListTags_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/myapp/tags/list", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tagsResponse{
+			Name: "myapp",
+			Tags: []string{"1.0", "1.1", "latest"},
+		})
+	})
+
+	srv, client := newTestServer(mux)
+	defer srv.Close()
+
+	ref := imageForServer(srv, "myapp")
+	tags, err := client.ListTags(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ListTags() error: %v", err)
+	}
+
+	if len(tags) != 3 {
+		t.Fatalf("expected 3 tags, got %d", len(tags))
+	}
+	want := []string{"1.0", "1.1", "latest"}
+	for i, tag := range tags {
+		if tag != want[i] {
+			t.Errorf("tag[%d] = %q, want %q", i, tag, want[i])
+		}
+	}
+}
+
+func TestOCIClient_ListTags_Pagination(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/myapp/tags/list", func(w http.ResponseWriter, r *http.Request) {
+		last := r.URL.Query().Get("last")
+		w.Header().Set("Content-Type", "application/json")
+
+		if last == "" {
+			// First page — include Link header for next page.
+			w.Header().Set("Link", `</v2/myapp/tags/list?last=tag2>; rel="next"`)
+			_ = json.NewEncoder(w).Encode(tagsResponse{
+				Name: "myapp",
+				Tags: []string{"tag1", "tag2"},
+			})
+		} else {
+			// Second page — no Link header.
+			_ = json.NewEncoder(w).Encode(tagsResponse{
+				Name: "myapp",
+				Tags: []string{"tag3", "tag4"},
+			})
+		}
+	})
+
+	srv, client := newTestServer(mux)
+	defer srv.Close()
+
+	ref := imageForServer(srv, "myapp")
+	tags, err := client.ListTags(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ListTags() error: %v", err)
+	}
+
+	if len(tags) != 4 {
+		t.Fatalf("expected 4 tags, got %d: %v", len(tags), tags)
+	}
+	want := []string{"tag1", "tag2", "tag3", "tag4"}
+	for i, tag := range tags {
+		if tag != want[i] {
+			t.Errorf("tag[%d] = %q, want %q", i, tag, want[i])
+		}
+	}
+}
+
+func TestOCIClient_ListTags_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/missing/tags/list", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv, client := newTestServer(mux)
+	defer srv.Close()
+
+	ref := imageForServer(srv, "missing")
+	_, err := client.ListTags(context.Background(), ref)
+	if err == nil {
+		t.Fatal("expected error for missing repository")
+	}
+	if !apperr.IsKind(err, apperr.NotFound) {
+		t.Errorf("expected NotFound error kind, got: %v", err)
+	}
+}
+
+func TestOCIClient_GetRemoteDigest_Success(t *testing.T) {
+	wantDigest := "sha256:abc123def456"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/myapp/manifests/1.0", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		accept := r.Header.Get("Accept")
+		if !strings.Contains(accept, "application/vnd.docker.distribution.manifest.v2+json") {
+			t.Errorf("missing expected Accept header, got: %s", accept)
+		}
+		w.Header().Set("Docker-Content-Digest", wantDigest)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv, client := newTestServer(mux)
+	defer srv.Close()
+
+	ref := imageForServer(srv, "myapp")
+	digest, err := client.GetRemoteDigest(context.Background(), ref, "1.0")
+	if err != nil {
+		t.Fatalf("GetRemoteDigest() error: %v", err)
+	}
+	if digest != wantDigest {
+		t.Errorf("digest = %q, want %q", digest, wantDigest)
+	}
+}
+
+func TestOCIClient_GetRemoteDigest_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/myapp/manifests/missing", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv, client := newTestServer(mux)
+	defer srv.Close()
+
+	ref := imageForServer(srv, "myapp")
+	_, err := client.GetRemoteDigest(context.Background(), ref, "missing")
+	if err == nil {
+		t.Fatal("expected error for missing tag")
+	}
+	if !apperr.IsKind(err, apperr.NotFound) {
+		t.Errorf("expected NotFound error kind, got: %v", err)
+	}
+}
+
+func TestOCIClient_GetRemoteDigest_EmptyTag(t *testing.T) {
+	client := NewOCIClient(nil)
+	_, err := client.GetRemoteDigest(context.Background(), ImageRef{}, "")
+	if err == nil {
+		t.Fatal("expected error for empty tag")
+	}
+	if !apperr.IsKind(err, apperr.InvalidInput) {
+		t.Errorf("expected InvalidInput error kind, got: %v", err)
+	}
+}
+
+func TestOCIClient_AuthFlow(t *testing.T) {
+	// Simulate a registry that requires token auth.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenResponse{Token: "test-token-123"})
+	}))
+	defer tokenSrv.Close()
+
+	callCount := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/secure/tags/list", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-token-123" {
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+				`Bearer realm="%s",service="test-registry",scope="repository:secure:pull"`,
+				tokenSrv.URL,
+			))
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tagsResponse{
+			Name: "secure",
+			Tags: []string{"v1"},
+		})
+	})
+
+	srv, client := newTestServer(mux)
+	defer srv.Close()
+
+	ref := imageForServer(srv, "secure")
+	tags, err := client.ListTags(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ListTags() with auth error: %v", err)
+	}
+	if len(tags) != 1 || tags[0] != "v1" {
+		t.Errorf("unexpected tags: %v", tags)
+	}
+
+	// Verify that the flow did an unauthenticated request then an authenticated retry.
+	if callCount != 2 {
+		t.Errorf("expected 2 calls to registry (unauth + auth), got %d", callCount)
+	}
+}
+
+func TestOCIClient_AuthFlow_TokenCached(t *testing.T) {
+	tokenRequests := 0
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		tokenRequests++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenResponse{Token: "cached-token"})
+	}))
+	defer tokenSrv.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/cached/tags/list", func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer cached-token" {
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+				`Bearer realm="%s",service="test",scope="repository:cached:pull"`,
+				tokenSrv.URL,
+			))
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tagsResponse{Name: "cached", Tags: []string{"v1"}})
+	})
+
+	srv, client := newTestServer(mux)
+	defer srv.Close()
+
+	ref := imageForServer(srv, "cached")
+
+	// First call — triggers auth.
+	_, err := client.ListTags(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("first ListTags() error: %v", err)
+	}
+
+	// Second call — should use cached token.
+	_, err = client.ListTags(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("second ListTags() error: %v", err)
+	}
+
+	if tokenRequests != 1 {
+		t.Errorf("expected 1 token request (cached on second call), got %d", tokenRequests)
+	}
+}
+
+func TestOCIClient_GetRemoteDigest_NoDigestHeader(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/myapp/manifests/bad", func(w http.ResponseWriter, _ *http.Request) {
+		// Return 200 but no Docker-Content-Digest header.
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv, client := newTestServer(mux)
+	defer srv.Close()
+
+	ref := imageForServer(srv, "myapp")
+	_, err := client.GetRemoteDigest(context.Background(), ref, "bad")
+	if err == nil {
+		t.Fatal("expected error for missing digest header")
+	}
+	if !apperr.IsKind(err, apperr.External) {
+		t.Errorf("expected External error kind, got: %v", err)
+	}
+}
+
+func TestOCIClient_ListTags_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/broken/tags/list", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	srv, client := newTestServer(mux)
+	defer srv.Close()
+
+	ref := imageForServer(srv, "broken")
+	_, err := client.ListTags(context.Background(), ref)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+	if !apperr.IsKind(err, apperr.External) {
+		t.Errorf("expected External error kind, got: %v", err)
+	}
+}
+
+func TestOCIClient_NetworkError(t *testing.T) {
+	// Create a server then immediately close it to simulate network error.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	client := NewOCIClient(srv.Client())
+	srv.Close()
+
+	ref := imageForServer(srv, "unreachable")
+	_, err := client.ListTags(context.Background(), ref)
+	if err == nil {
+		t.Fatal("expected error for network failure")
+	}
+}
+
+func TestParseNextLink(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		baseURL string
+		want    string
+	}{
+		{
+			name:    "relative link",
+			header:  `</v2/test/tags/list?last=foo>; rel="next"`,
+			baseURL: "https://registry.example.com",
+			want:    "https://registry.example.com/v2/test/tags/list?last=foo",
+		},
+		{
+			name:    "absolute link",
+			header:  `<https://other.com/v2/test/tags/list?last=foo>; rel="next"`,
+			baseURL: "https://registry.example.com",
+			want:    "https://other.com/v2/test/tags/list?last=foo",
+		},
+		{
+			name:    "empty header",
+			header:  "",
+			baseURL: "https://registry.example.com",
+			want:    "",
+		},
+		{
+			name:    "no next rel",
+			header:  `</v2/test/tags/list?last=foo>; rel="prev"`,
+			baseURL: "https://registry.example.com",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNextLink(tt.header, tt.baseURL)
+			if got != tt.want {
+				t.Errorf("parseNextLink() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,149 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gcstr/dockform/internal/apperr"
+)
+
+const (
+	defaultRegistry  = "registry-1.docker.io"
+	defaultNamespace = "library"
+	defaultTag       = "latest"
+)
+
+// Registry provides read-only access to container image registries.
+type Registry interface {
+	// ListTags returns all tags for an image from the remote registry.
+	ListTags(ctx context.Context, image ImageRef) ([]string, error)
+
+	// GetRemoteDigest returns the digest of a specific tag from the remote registry.
+	GetRemoteDigest(ctx context.Context, image ImageRef, tag string) (string, error)
+}
+
+// ImageRef represents a parsed container image reference.
+type ImageRef struct {
+	Registry  string // e.g., "registry-1.docker.io"
+	Namespace string // e.g., "library" for official images, "org" for ghcr
+	Name      string // e.g., "nginx"
+	Tag       string // e.g., "1.25", "latest", "" if untagged
+}
+
+// FullName returns the full repository path used in API calls (namespace/name).
+func (r ImageRef) FullName() string {
+	if r.Namespace == "" {
+		return r.Name
+	}
+	return r.Namespace + "/" + r.Name
+}
+
+// String returns the fully qualified image reference.
+func (r ImageRef) String() string {
+	s := r.Registry + "/" + r.FullName()
+	if r.Tag != "" {
+		s += ":" + r.Tag
+	}
+	return s
+}
+
+// ParseImageRef parses a raw image reference string into an ImageRef.
+//
+// It handles the following forms:
+//   - nginx                              → registry-1.docker.io/library/nginx:latest
+//   - nginx:1.25                         → registry-1.docker.io/library/nginx:1.25
+//   - ghcr.io/org/app:v1                 → ghcr.io/org/app:v1
+//   - registry.example.com/foo/bar:2.0   → as-is
+//   - registry.example.com:5000/foo:1.0  → registry with port
+func ParseImageRef(raw string) (ImageRef, error) {
+	const op = "registry.ParseImageRef"
+
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ImageRef{}, apperr.New(op, apperr.InvalidInput, "image reference cannot be empty")
+	}
+
+	var ref ImageRef
+
+	// Split off the tag (last colon that is not part of a port).
+	// We find the tag by looking at the part after the last slash.
+	lastSlash := strings.LastIndex(raw, "/")
+	nameAndTag := raw
+	if lastSlash >= 0 {
+		nameAndTag = raw[lastSlash+1:]
+	}
+
+	if idx := strings.LastIndex(nameAndTag, ":"); idx >= 0 {
+		ref.Tag = nameAndTag[idx+1:]
+		raw = raw[:len(raw)-len(ref.Tag)-1]
+	} else {
+		ref.Tag = defaultTag
+	}
+
+	if ref.Tag == "" {
+		return ImageRef{}, apperr.New(op, apperr.InvalidInput, "image tag cannot be empty")
+	}
+
+	// Now raw has no tag. Split into components.
+	parts := strings.Split(raw, "/")
+
+	switch {
+	case len(parts) == 1:
+		// Simple name like "nginx"
+		ref.Registry = defaultRegistry
+		ref.Namespace = defaultNamespace
+		ref.Name = parts[0]
+
+	case len(parts) == 2:
+		// Could be "library/nginx" (Docker Hub with namespace) or "ghcr.io/app"
+		if looksLikeRegistry(parts[0]) {
+			// e.g., "ghcr.io/app" — registry without namespace
+			ref.Registry = parts[0]
+			ref.Namespace = ""
+			ref.Name = parts[1]
+		} else {
+			// e.g., "myorg/myapp" — Docker Hub with org namespace
+			ref.Registry = defaultRegistry
+			ref.Namespace = parts[0]
+			ref.Name = parts[1]
+		}
+
+	case len(parts) >= 3:
+		// e.g., "ghcr.io/org/app" or "registry.example.com:5000/org/app"
+		ref.Registry = parts[0]
+		// Everything between the registry and the last part is namespace.
+		ref.Namespace = strings.Join(parts[1:len(parts)-1], "/")
+		ref.Name = parts[len(parts)-1]
+
+	default:
+		return ImageRef{}, apperr.New(op, apperr.InvalidInput, "cannot parse image reference: %s", raw)
+	}
+
+	if ref.Name == "" {
+		return ImageRef{}, apperr.New(op, apperr.InvalidInput, "image name cannot be empty")
+	}
+
+	return ref, nil
+}
+
+// looksLikeRegistry returns true if the string looks like a registry hostname
+// rather than a simple namespace. A registry hostname contains a dot or a colon
+// (for port), e.g., "ghcr.io", "registry.example.com", "localhost:5000".
+func looksLikeRegistry(s string) bool {
+	return strings.ContainsAny(s, ".:")
+}
+
+// registryURL returns the base URL for a registry, handling Docker Hub's
+// special index endpoint. If the registry already includes a scheme (e.g.,
+// from a test server), it is returned as-is.
+func registryURL(registry string) string {
+	if strings.HasPrefix(registry, "http://") || strings.HasPrefix(registry, "https://") {
+		return strings.TrimRight(registry, "/")
+	}
+	if registry == defaultRegistry {
+		return "https://registry-1.docker.io"
+	}
+	// Default to HTTPS for all registries.
+	return fmt.Sprintf("https://%s", registry)
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,166 @@
+package registry
+
+import (
+	"testing"
+)
+
+func TestParseImageRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    ImageRef
+		wantErr bool
+	}{
+		{
+			name: "simple image defaults to Docker Hub library",
+			raw:  "nginx",
+			want: ImageRef{
+				Registry:  "registry-1.docker.io",
+				Namespace: "library",
+				Name:      "nginx",
+				Tag:       "latest",
+			},
+		},
+		{
+			name: "image with tag",
+			raw:  "nginx:1.25",
+			want: ImageRef{
+				Registry:  "registry-1.docker.io",
+				Namespace: "library",
+				Name:      "nginx",
+				Tag:       "1.25",
+			},
+		},
+		{
+			name: "ghcr with org and tag",
+			raw:  "ghcr.io/org/app:v1",
+			want: ImageRef{
+				Registry:  "ghcr.io",
+				Namespace: "org",
+				Name:      "app",
+				Tag:       "v1",
+			},
+		},
+		{
+			name: "custom registry with nested path",
+			raw:  "registry.example.com/foo/bar:2.0",
+			want: ImageRef{
+				Registry:  "registry.example.com",
+				Namespace: "foo",
+				Name:      "bar",
+				Tag:       "2.0",
+			},
+		},
+		{
+			name: "registry with port",
+			raw:  "registry.example.com:5000/foo:1.0",
+			want: ImageRef{
+				Registry:  "registry.example.com:5000",
+				Namespace: "",
+				Name:      "foo",
+				Tag:       "1.0",
+			},
+		},
+		{
+			name: "Docker Hub with org namespace",
+			raw:  "myorg/myapp:latest",
+			want: ImageRef{
+				Registry:  "registry-1.docker.io",
+				Namespace: "myorg",
+				Name:      "myapp",
+				Tag:       "latest",
+			},
+		},
+		{
+			name: "Docker Hub org without tag defaults to latest",
+			raw:  "myorg/myapp",
+			want: ImageRef{
+				Registry:  "registry-1.docker.io",
+				Namespace: "myorg",
+				Name:      "myapp",
+				Tag:       "latest",
+			},
+		},
+		{
+			name: "registry with port and nested path",
+			raw:  "localhost:5000/myns/myimage:dev",
+			want: ImageRef{
+				Registry:  "localhost:5000",
+				Namespace: "myns",
+				Name:      "myimage",
+				Tag:       "dev",
+			},
+		},
+		{
+			name:    "empty string",
+			raw:     "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			raw:     "   ",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseImageRef(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseImageRef(%q) expected error, got nil", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseImageRef(%q) unexpected error: %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseImageRef(%q)\n  got:  %+v\n  want: %+v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestImageRef_FullName(t *testing.T) {
+	tests := []struct {
+		ref  ImageRef
+		want string
+	}{
+		{
+			ref:  ImageRef{Namespace: "library", Name: "nginx"},
+			want: "library/nginx",
+		},
+		{
+			ref:  ImageRef{Namespace: "", Name: "app"},
+			want: "app",
+		},
+		{
+			ref:  ImageRef{Namespace: "org/sub", Name: "app"},
+			want: "org/sub/app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.ref.FullName()
+			if got != tt.want {
+				t.Errorf("FullName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestImageRef_String(t *testing.T) {
+	ref := ImageRef{
+		Registry:  "registry-1.docker.io",
+		Namespace: "library",
+		Name:      "nginx",
+		Tag:       "1.25",
+	}
+	want := "registry-1.docker.io/library/nginx:1.25"
+	got := ref.String()
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
**New commands**

`dockform images check`: compares images referenced in stacks against their upstream registries, flagging drift (digest changed, newer tag available, etc.).
`dockform images upgrade`: rewrites image tags in compose files to the latest upstream version.

**New internal package — internal/registry**

OCI registry client (registry.go, oci.go) that speaks the OCI Distribution Spec: manifest fetches, Accept headers for OCI image indexes and manifest lists, digest comparison.

**Config**

New Images config type.
Fix to merge Images config from explicit stacks into discovered stacks so image‑level configuration survives manifest discovery.
Performance & correctness iterations (visible as a back‑and‑forth in the log)
