### PR TITLE
docs: fix go install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ brew install dockform
 ### Go
 
 ```sh
-go install github.com/gcstr/dockform@latest
+go install github.com/gcstr/dockform/cmd/dockform@latest
 ```
 
 ### From source


### PR DESCRIPTION
Small update to the `go install` URL after failed installation using the previously documented command:

```sh
$ go install github.com/gcstr/dockform@latest
go: downloading github.com/gcstr/dockform v0.9.0
go: github.com/gcstr/dockform@v0.9.0 requires go >= 1.25.0; switching to go1.25.10
go: downloading go1.25.10 (linux/amd64)
go: github.com/gcstr/dockform@latest: module github.com/gcstr/dockform@latest found (v0.9.0), but does not contain package github.com/gcstr/dockform
```

Fixed with the new command in the PR:

```sh
$ go install github.com/gcstr/dockform/cmd/dockform@latest
go: github.com/gcstr/dockform@v0.9.0 requires go >= 1.25.0; switching to go1.25.10
go: downloading github.com/spf13/cobra v1.8.1
go: downloading github.com/charmbracelet/bubbles/v2 v2.0.0-beta.1
go: downloading github.com/charmbracelet/bubbletea/v2 v2.0.0-beta.4
go: downloading github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3
go: downloading github.com/charmbracelet/log v0.4.0
go: downloading github.com/mattn/go-isatty v0.0.20
go: downloading github.com/charmbracelet/lipgloss v1.1.0
go: downloading github.com/goccy/go-yaml v1.18.0
go: downloading github.com/go-playground/validator/v10 v10.20.0
go: downloading github.com/charmbracelet/bubbletea v1.1.0
go: downloading github.com/charmbracelet/bubbles v0.20.0
go: downloading github.com/alecthomas/chroma/v2 v2.13.0
go: downloading github.com/charmbracelet/x/ansi v0.9.3
go: downloading github.com/creack/pty v1.1.21
go: downloading golang.org/x/term v0.37.0
go: downloading filippo.io/age v1.2.1
go: downloading github.com/muesli/termenv v0.16.0
go: downloading golang.org/x/sys v0.38.0
go: downloading github.com/go-logfmt/logfmt v0.6.0
go: downloading github.com/Masterminds/semver/v3 v3.4.0
go: downloading github.com/bmatcuk/doublestar/v4 v4.6.1
go: downloading github.com/charmbracelet/x/cellbuf v0.0.14-0.20250505150409-97991a1f17d1
go: downloading github.com/rivo/uniseg v0.4.7
go: downloading github.com/charmbracelet/colorprofile v0.3.1
go: downloading github.com/charmbracelet/x/term v0.2.1
go: downloading github.com/lucasb-eyer/go-colorful v1.2.0
go: downloading github.com/muesli/cancelreader v0.2.2
go: downloading github.com/gabriel-vasile/mimetype v1.4.3
go: downloading github.com/go-playground/universal-translator v0.18.1
go: downloading github.com/leodido/go-urn v1.4.0
go: downloading golang.org/x/crypto v0.45.0
go: downloading golang.org/x/text v0.31.0
go: downloading github.com/charmbracelet/harmonica v0.2.0
go: downloading github.com/atotto/clipboard v0.1.4
go: downloading github.com/mattn/go-runewidth v0.0.16
go: downloading github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6
go: downloading golang.org/x/sync v0.18.0
go: downloading github.com/sahilm/fuzzy v0.1.1
go: downloading github.com/charmbracelet/x/input v0.3.7
go: downloading github.com/aymanbagabas/go-osc52/v2 v2.0.1
go: downloading github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e
go: downloading github.com/go-playground/locales v0.14.1
go: downloading github.com/dlclark/regexp2 v1.11.0
go: downloading golang.org/x/net v0.47.0
```