### PR TITLE
fix: scope destroy --stack to targeted stacks instead of everything

### DIFF
--- a/internal/cli/common/confirmation.go
+++ b/internal/cli/common/confirmation.go
@@ -72,6 +72,9 @@ func GetConfirmation(cmd *cobra.Command, pr ui.Printer, opts ConfirmationOptions
 type DestroyConfirmationOptions struct {
 	SkipConfirmation bool
 	Identifier       string
+	// Targeted indicates the destroy was scoped by --stack/--context/--deployment,
+	// so only the targeted resources (shown in the plan) will be removed.
+	Targeted bool
 }
 
 // GetDestroyConfirmation handles user confirmation for destroy operations,
@@ -82,6 +85,9 @@ func GetDestroyConfirmation(cmd *cobra.Command, pr ui.Printer, opts DestroyConfi
 	}
 
 	msgSummary := fmt.Sprintf("│ This will destroy ALL managed resources with identifier '%s'.\n│ This operation is IRREVERSIBLE.", opts.Identifier)
+	if opts.Targeted {
+		msgSummary = fmt.Sprintf("│ This will destroy the targeted resources shown above (identifier '%s').\n│ This operation is IRREVERSIBLE.", opts.Identifier)
+	}
 	msgInstr := fmt.Sprintf("│ Type the identifier name '%s' to confirm.\n│", ui.ConfirmToken(opts.Identifier))
 
 	tty := detectTTY(cmd)

--- a/internal/cli/destroycmd/new.go
+++ b/internal/cli/destroycmd/new.go
@@ -23,7 +23,11 @@ This command will:
 - Destroy resources in the correct order (containers → networks → volumes)
 
 Warning: This operation is irreversible and will destroy ALL managed resources,
-regardless of what's in your current configuration file.`,
+regardless of what's in your current configuration file.
+
+Use --stack or --context to scope the destroy. When scoped, only the targeted
+stacks' services and their own fileset volumes are removed; shared context-level
+networks and volumes are preserved.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			skipConfirm, _ := cmd.Flags().GetBool("skip-confirmation")
 
@@ -60,6 +64,7 @@ regardless of what's in your current configuration file.`,
 			confirmed, err := common.GetDestroyConfirmation(cmd, ctx.Printer, common.DestroyConfirmationOptions{
 				SkipConfirmation: skipConfirm,
 				Identifier:       identifier,
+				Targeted:         ctx.Config.Targeted,
 			})
 			if err != nil {
 				return err

--- a/internal/planner/destroy.go
+++ b/internal/planner/destroy.go
@@ -10,6 +10,52 @@ import (
 	"github.com/gcstr/dockform/internal/manifest"
 )
 
+// destroyScope describes how a destroy operation is narrowed when the config has
+// been targeted (e.g. via --stack/--context). When targeted is false, destroy
+// removes every identifier-labeled resource (the default nuke-everything mode).
+//
+// When targeted is true, only the targeted stacks' services and their own fileset
+// volumes are removed; context-level shared networks and volumes are preserved
+// (GH #55).
+type destroyScope struct {
+	targeted bool
+	// projects is the set of "context/project" keys belonging to targeted stacks.
+	projects map[string]bool
+}
+
+// allowsStack reports whether a discovered compose project on contextName is in scope.
+func (s destroyScope) allowsStack(contextName, project string) bool {
+	if !s.targeted {
+		return true
+	}
+	if project == "" {
+		return false // orphan containers belong to no targeted stack
+	}
+	return s.projects[manifest.MakeStackKey(contextName, project)]
+}
+
+// newDestroyScope computes the destroy scope from a (possibly targeted) config.
+// The targeted config's Stacks/DiscoveredStacks have already been filtered by
+// ResolveTargets, so they describe exactly the stacks in scope.
+func newDestroyScope(cfg *manifest.Config) destroyScope {
+	if !cfg.Targeted {
+		return destroyScope{targeted: false}
+	}
+	projects := make(map[string]bool)
+	for key, stack := range cfg.GetAllStacks() {
+		context, stackName, err := manifest.ParseStackKey(key)
+		if err != nil {
+			continue
+		}
+		proj := stackName
+		if stack.Project != nil && stack.Project.Name != "" {
+			proj = stack.Project.Name
+		}
+		projects[manifest.MakeStackKey(context, proj)] = true
+	}
+	return destroyScope{targeted: true, projects: projects}
+}
+
 // BuildDestroyPlan creates a plan to destroy all managed resources.
 // Unlike BuildPlan, this discovers all labeled resources regardless of configuration.
 func (p *Planner) BuildDestroyPlan(ctx context.Context, cfg manifest.Config) (*Plan, error) {
@@ -27,6 +73,7 @@ func (p *Planner) BuildDestroyPlan(ctx context.Context, cfg manifest.Config) (*P
 	for fsName, fs := range allFilesets {
 		volumeToFileset[fs.TargetVolume] = fsName
 	}
+	scope := newDestroyScope(&cfg)
 
 	var mu sync.Mutex
 
@@ -36,7 +83,7 @@ func (p *Planner) BuildDestroyPlan(ctx context.Context, cfg manifest.Config) (*P
 			return apperr.New("planner.BuildDestroyPlan", apperr.Precondition, "docker client not available for context %s", contextName)
 		}
 
-		localRP, err := p.buildDestroyPlanForContext(ctx, client, contextName, allFilesets, volumeToFileset)
+		localRP, err := p.buildDestroyPlanForContext(ctx, client, contextName, allFilesets, volumeToFileset, scope)
 		if err != nil {
 			return err
 		}
@@ -54,7 +101,7 @@ func (p *Planner) BuildDestroyPlan(ctx context.Context, cfg manifest.Config) (*P
 }
 
 // buildDestroyPlanForContext discovers labeled resources on a single context.
-func (p *Planner) buildDestroyPlanForContext(ctx context.Context, client DockerClient, contextName string, allFilesets map[string]manifest.FilesetSpec, volumeToFileset map[string]string) (*ResourcePlan, error) {
+func (p *Planner) buildDestroyPlanForContext(ctx context.Context, client DockerClient, contextName string, allFilesets map[string]manifest.FilesetSpec, volumeToFileset map[string]string, scope destroyScope) (*ResourcePlan, error) {
 	rp := &ResourcePlan{
 		Stacks:   make(map[string][]Resource),
 		Filesets: make(map[string][]Resource),
@@ -68,6 +115,9 @@ func (p *Planner) buildDestroyPlanForContext(ctx context.Context, client DockerC
 
 	stackServices := make(map[string]map[string]struct{})
 	for _, container := range containers {
+		if !scope.allowsStack(contextName, container.Project) {
+			continue
+		}
 		if container.Project != "" {
 			if stackServices[container.Project] == nil {
 				stackServices[container.Project] = make(map[string]struct{})
@@ -88,14 +138,17 @@ func (p *Planner) buildDestroyPlanForContext(ctx context.Context, client DockerC
 		}
 	}
 
-	// Discover all labeled networks
-	networks, err := client.ListNetworks(ctx)
-	if err != nil {
-		return nil, apperr.Wrap("planner.BuildDestroyPlan", apperr.External, err, "context %s: list networks", contextName)
-	}
-	for _, network := range networks {
-		res := NewResource(ResourceNetwork, network, ActionDelete, "will be destroyed")
-		rp.Networks = append(rp.Networks, res)
+	// Discover all labeled networks. Context-level networks are shared
+	// infrastructure, so a scoped (targeted) destroy never removes them.
+	if !scope.targeted {
+		networks, err := client.ListNetworks(ctx)
+		if err != nil {
+			return nil, apperr.Wrap("planner.BuildDestroyPlan", apperr.External, err, "context %s: list networks", contextName)
+		}
+		for _, network := range networks {
+			res := NewResource(ResourceNetwork, network, ActionDelete, "will be destroyed")
+			rp.Networks = append(rp.Networks, res)
+		}
 	}
 
 	// Discover all labeled volumes
@@ -113,7 +166,9 @@ func (p *Planner) buildDestroyPlanForContext(ctx context.Context, client DockerC
 			details := fmt.Sprintf("volume %s at %s will be destroyed", volume, fsConfig.TargetPath)
 			res := NewResource(ResourceFile, "", ActionDelete, details)
 			rp.Filesets[filesetName] = append(rp.Filesets[filesetName], res)
-		} else {
+		} else if !scope.targeted {
+			// Non-fileset volumes are shared/context-level: only removed in a
+			// full (untargeted) destroy.
 			res := NewResource(ResourceVolume, volume, ActionDelete, "will be destroyed")
 			rp.Volumes = append(rp.Volumes, res)
 		}
@@ -147,6 +202,11 @@ func (p *Planner) DestroyWithOptions(ctx context.Context, cfg manifest.Config, o
 	}
 
 	allFilesets := cfg.GetAllFilesets()
+	volumeToFileset := make(map[string]string)
+	for fsName, fs := range allFilesets {
+		volumeToFileset[fs.TargetVolume] = fsName
+	}
+	scope := newDestroyScope(&cfg)
 
 	err := p.ExecuteAcrossContexts(ctx, &cfg, func(ctx context.Context, contextName string) error {
 		client := p.getClientForContext(contextName, &cfg)
@@ -154,7 +214,7 @@ func (p *Planner) DestroyWithOptions(ctx context.Context, cfg manifest.Config, o
 			return apperr.New("planner.Destroy", apperr.Precondition, "docker client not available for context %s", contextName)
 		}
 
-		return p.destroyContext(ctx, client, contextName, allFilesets, opts.VerboseErrors)
+		return p.destroyContext(ctx, client, contextName, volumeToFileset, scope, opts.VerboseErrors)
 	})
 	return handleCleanupError(ctx, err, opts, "destroy")
 }
@@ -162,7 +222,7 @@ func (p *Planner) DestroyWithOptions(ctx context.Context, cfg manifest.Config, o
 // destroyContext executes destruction for a single context.
 // Errors during resource removal are logged but do not stop the destruction process
 // to ensure best-effort cleanup of all resources.
-func (p *Planner) destroyContext(ctx context.Context, client DockerClient, contextName string, allFilesets map[string]manifest.FilesetSpec, verboseErrors bool) error {
+func (p *Planner) destroyContext(ctx context.Context, client DockerClient, contextName string, volumeToFileset map[string]string, scope destroyScope, verboseErrors bool) error {
 	log := logger.FromContext(ctx).With("component", "planner", "action", "destroy", "context", contextName)
 	var errs []error
 
@@ -178,6 +238,9 @@ func (p *Planner) destroyContext(ctx context.Context, client DockerClient, conte
 	}
 	byProjSvc := make(map[string]map[string][]string)
 	for _, it := range allContainers {
+		if !scope.allowsStack(contextName, it.Project) {
+			continue
+		}
 		if it.Project == "" {
 			// Orphaned container
 			if p.spinner != nil {
@@ -217,31 +280,35 @@ func (p *Planner) destroyContext(ctx context.Context, client DockerClient, conte
 		}
 	}
 
-	// Step 2: Remove networks
-	networks, err := client.ListNetworks(ctx)
-	if err != nil {
-		errs = append(errs, apperr.Wrap("planner.destroyContext", apperr.External, err, "context %s: list networks", contextName))
-		if verboseErrors {
-			log.Warn("destroy_list_networks_failed", "error", err.Error())
-		} else {
-			log.Warn("destroy_list_networks_failed")
-		}
-	}
-	for _, network := range networks {
-		if p.spinner != nil {
-			p.spinner.SetLabel(fmt.Sprintf("removing network %s on %s", network, contextName))
-		}
-		if err := client.RemoveNetwork(ctx, network); err != nil {
-			errs = append(errs, apperr.Wrap("planner.destroyContext", apperr.External, err, "context %s: remove network %s", contextName, network))
+	// Step 2: Remove networks. Context-level networks are shared infrastructure,
+	// so a scoped (targeted) destroy never removes them.
+	if !scope.targeted {
+		networks, err := client.ListNetworks(ctx)
+		if err != nil {
+			errs = append(errs, apperr.Wrap("planner.destroyContext", apperr.External, err, "context %s: list networks", contextName))
 			if verboseErrors {
-				log.Warn("destroy_remove_network_failed", "network", network, "error", err.Error())
+				log.Warn("destroy_list_networks_failed", "error", err.Error())
 			} else {
-				log.Warn("destroy_remove_network_failed", "network", network)
+				log.Warn("destroy_list_networks_failed")
+			}
+		}
+		for _, network := range networks {
+			if p.spinner != nil {
+				p.spinner.SetLabel(fmt.Sprintf("removing network %s on %s", network, contextName))
+			}
+			if err := client.RemoveNetwork(ctx, network); err != nil {
+				errs = append(errs, apperr.Wrap("planner.destroyContext", apperr.External, err, "context %s: remove network %s", contextName, network))
+				if verboseErrors {
+					log.Warn("destroy_remove_network_failed", "network", network, "error", err.Error())
+				} else {
+					log.Warn("destroy_remove_network_failed", "network", network)
+				}
 			}
 		}
 	}
 
-	// Step 3: Remove volumes
+	// Step 3: Remove volumes. Under a scoped destroy, only the targeted stacks'
+	// fileset volumes are removed; shared/context-level volumes are preserved.
 	volumes, err := client.ListVolumes(ctx)
 	if err != nil {
 		errs = append(errs, apperr.Wrap("planner.destroyContext", apperr.External, err, "context %s: list volumes", contextName))
@@ -252,6 +319,11 @@ func (p *Planner) destroyContext(ctx context.Context, client DockerClient, conte
 		}
 	}
 	for _, volume := range volumes {
+		if scope.targeted {
+			if _, isFileset := volumeToFileset[volume]; !isFileset {
+				continue
+			}
+		}
 		if p.spinner != nil {
 			p.spinner.SetLabel(fmt.Sprintf("removing volume %s on %s", volume, contextName))
 		}

--- a/internal/planner/destroy_test.go
+++ b/internal/planner/destroy_test.go
@@ -113,3 +113,57 @@ func TestDestroy_OptimizedContainerLookup(t *testing.T) {
 		t.Errorf("Expected 2 web containers removed, got %d", webCount)
 	}
 }
+
+// TestDestroy_ScopedToStack verifies that when the config is targeted (e.g. via
+// --stack), destroy only removes the targeted stack's services and its own
+// fileset volumes, leaving other stacks and context-level shared
+// networks/volumes untouched. Regression test for GH #55.
+func TestDestroy_ScopedToStack(t *testing.T) {
+	baseMock := newMockDocker()
+	baseMock.containers = []dockercli.PsBrief{
+		{Project: "nginx", Service: "nginx", Name: "nginx-nginx-1"},
+		{Project: "traefik", Service: "traefik", Name: "traefik-traefik-1"},
+	}
+	baseMock.networks = []string{"proxy", "traefik"}
+	baseMock.volumes = []string{"nginx-config", "traefik-config", "traefik-logs"}
+
+	mockCounter := &mockDockerListCounter{mockDockerClient: baseMock}
+
+	// Config targeted to services/nginx only.
+	cfg := manifest.Config{
+		Identifier: "test",
+		Targeted:   true,
+		Contexts: map[string]manifest.ContextConfig{
+			"services": {},
+		},
+		Stacks: map[string]manifest.Stack{
+			"services/nginx": {Context: "services"},
+		},
+		DiscoveredFilesets: map[string]manifest.FilesetSpec{
+			"nginx-config": {TargetVolume: "nginx-config", Context: "services", Stack: "nginx"},
+		},
+	}
+
+	planner := NewWithDocker(mockCounter)
+	ctx := context.Background()
+
+	if err := planner.Destroy(ctx, cfg); err != nil {
+		t.Fatalf("Destroy failed: %v", err)
+	}
+
+	// Only the nginx service container should be removed.
+	if got := mockCounter.removedContainers; len(got) != 1 || got[0] != "nginx-nginx-1" {
+		t.Errorf("Expected only nginx-nginx-1 removed, got %v", got)
+	}
+
+	// Context-level shared networks must NOT be removed under a scoped destroy.
+	if got := mockCounter.removedNetworks; len(got) != 0 {
+		t.Errorf("Expected no networks removed under scoped destroy, got %v", got)
+	}
+
+	// Only the targeted stack's fileset volume should be removed; shared/other
+	// volumes must be left alone.
+	if got := mockCounter.removedVolumes; len(got) != 1 || got[0] != "nginx-config" {
+		t.Errorf("Expected only nginx-config volume removed, got %v", got)
+	}
+}

--- a/test/e2e/destroy_test.go
+++ b/test/e2e/destroy_test.go
@@ -354,3 +354,102 @@ func TestDestroy_IndependentOfConfigFile(t *testing.T) {
 
 	t.Logf("Successfully destroyed resources independent of config file content")
 }
+
+// TestDestroy_ScopedToStack verifies that `destroy --stack <context/stack>` only
+// removes the targeted stack's services, leaving other stacks, the shared
+// context-level network, and non-fileset volumes intact. Regression test for
+// GH #55, where a scoped destroy tore down ALL managed resources.
+func TestDestroy_ScopedToStack(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not found in PATH")
+	}
+
+	// Log context and apply safety gate
+	ctx := context.Background()
+	_ = logDockerContext(t)
+	if looksProd(t) && os.Getenv("E2E_ALLOW_HOST") != "1" {
+		t.Skip("refusing to run e2e against a production-looking daemon; set E2E_ALLOW_HOST=1 to override")
+	}
+
+	// Unique run id and identifier
+	runID := uniqueID()
+	identifier := runID
+	ensureNetworkCreatableOrSkip(t, identifier)
+
+	app1Project := "df_e2e_" + runID + "_app1"
+	app2Project := "df_e2e_" + runID + "_app2"
+
+	// Pre-create external volumes referenced by each stack's compose since the
+	// planner does not create top-level external volumes.
+	_ = exec.Command("docker", "volume", "create", "--label", "io.dockform.identifier="+identifier, "df_e2e_"+runID+"_vol1").Run()
+	_ = exec.Command("docker", "volume", "create", "--label", "io.dockform.identifier="+identifier, "df_e2e_"+runID+"_vol2").Run()
+
+	// Build dockform once and reuse path
+	bin := buildDockform(t)
+
+	// Always cleanup labeled resources
+	t.Cleanup(func() {
+		cleanupByLabel(t, identifier)
+	})
+
+	// Prepare temp workdir by copying scenario
+	tempDir := t.TempDir()
+	src := filepath.Join("testdata", "scenarios", "multi_stack")
+	if err := copyTree(src, tempDir); err != nil {
+		t.Fatalf("copy scenario: %v", err)
+	}
+
+	env := append(os.Environ(), "DOCKFORM_RUN_ID="+runID)
+
+	// 1. APPLY: Create both stacks, the shared network, and both volumes
+	stdout, stderr, code := runCmdWithStdinDetailed(t, tempDir, env, bin, "yes\n", "apply", "--manifest", tempDir)
+	if code != 0 {
+		t.Fatalf("apply failed with exit code %d\nSTDOUT:\n%s\nSTDERR:\n%s", code, stdout, stderr)
+	}
+
+	// Assert both stacks' containers exist before destroy
+	app1Before := dockerLines(t, ctx, "ps", "-a", "--format", "{{.Names}}", "--filter", "label=com.docker.compose.project="+app1Project)
+	app2Before := dockerLines(t, ctx, "ps", "-a", "--format", "{{.Names}}", "--filter", "label=com.docker.compose.project="+app2Project)
+	if len(app1Before) == 0 || len(app2Before) == 0 {
+		t.Fatalf("expected both stacks to have containers before destroy: app1=%v app2=%v", app1Before, app2Before)
+	}
+
+	// 2. DESTROY SCOPED TO app1 ONLY
+	destroyOut, destroyErr, destroyCode := runCmdWithStdinDetailed(t, tempDir, env, bin, identifier+"\n", "destroy", "--stack", "default/app1", "--manifest", tempDir)
+	if destroyCode != 0 {
+		t.Fatalf("scoped destroy failed with exit code %d\nSTDOUT:\n%s\nSTDERR:\n%s", destroyCode, destroyOut, destroyErr)
+	}
+
+	// Confirmation copy should reflect the scoped (targeted) destroy, not the
+	// full "ALL managed resources" warning.
+	if !strings.Contains(destroyOut, "targeted resources shown above") {
+		t.Fatalf("scoped destroy should show targeted confirmation copy:\n%s", destroyOut)
+	}
+	if strings.Contains(destroyOut, "destroy ALL managed resources") {
+		t.Fatalf("scoped destroy must not show the ALL-resources warning:\n%s", destroyOut)
+	}
+
+	// 3. VERIFY ONLY app1 WAS DESTROYED
+	app1After := dockerLines(t, ctx, "ps", "-a", "--format", "{{.Names}}", "--filter", "label=com.docker.compose.project="+app1Project)
+	app2After := dockerLines(t, ctx, "ps", "-a", "--format", "{{.Names}}", "--filter", "label=com.docker.compose.project="+app2Project)
+	if len(app1After) != 0 {
+		t.Fatalf("expected app1 containers to be destroyed, but found: %v", app1After)
+	}
+	if len(app2After) == 0 {
+		t.Fatalf("expected app2 containers to survive scoped destroy, but none found")
+	}
+
+	// Shared context-level network must be preserved.
+	networksAfter := dockerLines(t, ctx, "network", "ls", "--format", "{{.Name}}", "--filter", "label=io.dockform.identifier="+identifier)
+	if len(networksAfter) == 0 {
+		t.Fatalf("expected shared network to survive scoped destroy, but none found")
+	}
+
+	// Non-fileset volumes (both stacks') must be preserved.
+	volumesAfter := dockerLines(t, ctx, "volume", "ls", "--format", "{{.Name}}", "--filter", "label=io.dockform.identifier="+identifier)
+	if len(volumesAfter) != 2 {
+		t.Fatalf("expected both volumes to survive scoped destroy, found: %v", volumesAfter)
+	}
+
+	t.Logf("Scoped destroy removed only app1; app2, shared network, and volumes preserved")
+}

--- a/test/e2e/testdata/scenarios/multi_stack/app1/docker-compose.yaml
+++ b/test/e2e/testdata/scenarios/multi_stack/app1/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  hello1:
+    image: alpine
+    command: ["sh", "-c", "sleep 5m"]
+    labels:
+      io.dockform.identifier: ${DOCKFORM_RUN_ID}
+    volumes:
+      - data:/data
+    networks:
+      - net
+
+volumes:
+  data:
+    external: true
+    name: "df_e2e_${DOCKFORM_RUN_ID}_vol1"
+
+networks:
+  net:
+    external: true
+    name: "df_e2e_${DOCKFORM_RUN_ID}_net"

--- a/test/e2e/testdata/scenarios/multi_stack/app2/docker-compose.yaml
+++ b/test/e2e/testdata/scenarios/multi_stack/app2/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  hello2:
+    image: alpine
+    command: ["sh", "-c", "sleep 5m"]
+    labels:
+      io.dockform.identifier: ${DOCKFORM_RUN_ID}
+    volumes:
+      - data:/data
+    networks:
+      - net
+
+volumes:
+  data:
+    external: true
+    name: "df_e2e_${DOCKFORM_RUN_ID}_vol2"
+
+networks:
+  net:
+    external: true
+    name: "df_e2e_${DOCKFORM_RUN_ID}_net"

--- a/test/e2e/testdata/scenarios/multi_stack/dockform.yml
+++ b/test/e2e/testdata/scenarios/multi_stack/dockform.yml
@@ -1,0 +1,20 @@
+identifier: ${DOCKFORM_RUN_ID}
+
+contexts:
+  default:
+    networks:
+      df_e2e_${DOCKFORM_RUN_ID}_net: {}
+
+stacks:
+  default/app1:
+    root: app1
+    files:
+      - docker-compose.yaml
+    project:
+      name: df_e2e_${DOCKFORM_RUN_ID}_app1
+  default/app2:
+    root: app2
+    files:
+      - docker-compose.yaml
+    project:
+      name: df_e2e_${DOCKFORM_RUN_ID}_app2


### PR DESCRIPTION
`dockform destroy --stack <context/stack>` ignored scoping and planned to destroy every resource with the `io.dockform.identifier` label including other stacks, shared networks, and all volumes included

Added a `destroyScope` that gates both the plan and apply


Resource | Default (untargeted) | Scoped (--stack/--context)
-- | -- | --
Containers / services | all labeled | only targeted stacks' compose projects (orphans skipped)
Networks | all labeled | preserved (shared context-level infra)
Volumes | all labeled | only targeted stacks' fileset volumes; shared/non-fileset volumes preserved

The default, unscoped destroy is unchanged 

Fixes #55  