### PR TITLE
fix: don't flag compose-defined networks for deletion on second apply

### DIFF
--- a/internal/dockercli/networks.go
+++ b/internal/dockercli/networks.go
@@ -23,6 +23,23 @@ func (c *Client) ListNetworks(ctx context.Context) ([]string, error) {
 	return util.SplitNonEmptyLines(out), nil
 }
 
+// ListComposeNetworks returns names of identifier-labeled networks that are owned
+// by a compose stack. Compose stamps the com.docker.compose.project label onto
+// networks it creates; dockform's own CreateNetwork does not. The label filters
+// are ANDed, so this returns only networks managed by a compose project.
+func (c *Client) ListComposeNetworks(ctx context.Context) ([]string, error) {
+	args := []string{"network", "ls", "--format", "{{.Name}}"}
+	if c.identifier != "" {
+		args = append(args, "--filter", "label=io.dockform.identifier="+c.identifier)
+	}
+	args = append(args, "--filter", "label=com.docker.compose.project")
+	out, err := c.exec.Run(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	return util.SplitNonEmptyLines(out), nil
+}
+
 // NetworkSummary contains key metadata about a network for dashboard display.
 type NetworkSummary struct {
 	Name   string

--- a/internal/planner/build_plan.go
+++ b/internal/planner/build_plan.go
@@ -177,13 +177,21 @@ func (p *Planner) buildContextPlan(ctx context.Context, cfg manifest.Config, con
 				NewResource(ResourceNetwork, name, ActionCreate, ""))
 		}
 	}
-	// Plan removals for labeled networks no longer needed (skip when targeting specific stacks)
+	// Plan removals for labeled networks no longer needed (skip when targeting specific stacks).
+	// Compose-owned networks carry the identifier label but are managed by their
+	// stack's lifecycle, so they must not be reported as orphans (GH #54).
 	if !cfg.Targeted {
-		for name := range existingNetworks {
-			if _, want := desiredNetworks[name]; !want {
-				resourcePlan.Networks = append(resourcePlan.Networks,
-					NewResource(ResourceNetwork, name, ActionDelete, ""))
+		var composeOwnedNetworks map[string]struct{}
+		if client != nil {
+			owned, err := p.getComposeOwnedNetworks(ctx, client)
+			if err != nil {
+				return nil, err
 			}
+			composeOwnedNetworks = owned
+		}
+		for _, name := range orphanNetworks(existingNetworks, desiredNetworks, composeOwnedNetworks) {
+			resourcePlan.Networks = append(resourcePlan.Networks,
+				NewResource(ResourceNetwork, name, ActionDelete, ""))
 		}
 	}
 

--- a/internal/planner/build_plan_filesets.go
+++ b/internal/planner/build_plan_filesets.go
@@ -165,6 +165,41 @@ func (p *Planner) getExistingResourcesForClient(ctx context.Context, client Dock
 	return volumes, networks, apperr.Aggregate("planner.getExistingResourcesForClient", apperr.External, "failed to discover existing docker resources", errs...)
 }
 
+// getComposeOwnedNetworks returns the set of identifier-labeled networks that are
+// owned by a compose stack (they also carry the com.docker.compose.project label).
+// These must be excluded from orphan detection: dockform injects its identifier
+// label onto compose-defined networks so destroy can find them, but their
+// lifecycle belongs to the stack, not to dockform (GH #54).
+func (p *Planner) getComposeOwnedNetworks(ctx context.Context, client DockerClient) (map[string]struct{}, error) {
+	owned := map[string]struct{}{}
+	nets, err := client.ListComposeNetworks(ctx)
+	if err != nil {
+		return nil, apperr.Wrap("planner.getComposeOwnedNetworks", apperr.External, err, "list compose-owned networks")
+	}
+	for _, n := range nets {
+		owned[n] = struct{}{}
+	}
+	return owned, nil
+}
+
+// orphanNetworks returns the labeled networks that should be removed: those no
+// longer desired and not owned by a compose stack. Compose-owned networks carry
+// the identifier label but are managed by their stack's lifecycle, so they are
+// never treated as dockform orphans (GH #54).
+func orphanNetworks(existing, desired, composeOwned map[string]struct{}) []string {
+	var orphans []string
+	for name := range existing {
+		if _, want := desired[name]; want {
+			continue
+		}
+		if _, owned := composeOwned[name]; owned {
+			continue
+		}
+		orphans = append(orphans, name)
+	}
+	return orphans
+}
+
 // aggregateContextPlan merges a context plan into the aggregated plan.
 func (p *Planner) aggregateContextPlan(aggregated *ResourcePlan, contextPlan *ContextPlan) {
 	if contextPlan == nil || contextPlan.Resources == nil {

--- a/internal/planner/interfaces.go
+++ b/internal/planner/interfaces.go
@@ -24,6 +24,9 @@ type DockerClient interface {
 
 	// Network operations
 	ListNetworks(ctx context.Context) ([]string, error)
+	// ListComposeNetworks returns identifier-labeled networks owned by a compose
+	// stack (also carrying the com.docker.compose.project label).
+	ListComposeNetworks(ctx context.Context) ([]string, error)
 	CreateNetwork(ctx context.Context, name string, labels map[string]string, opts ...dockercli.NetworkCreateOpts) error
 	RemoveNetwork(ctx context.Context, name string) error
 	InspectNetwork(ctx context.Context, name string) (dockercli.NetworkInspect, error)

--- a/internal/planner/mock_docker_test.go
+++ b/internal/planner/mock_docker_test.go
@@ -13,6 +13,7 @@ type mockDockerClient struct {
 	// Mock data to return
 	volumes         []string
 	networks        []string
+	composeNetworks []string // subset of networks owned by a compose stack
 	containers      []dockercli.PsBrief
 	composePsItems  []dockercli.ComposePsItem
 	volumeFiles     map[string]string            // volumeName -> file content
@@ -156,6 +157,13 @@ func (m *mockDockerClient) ListNetworks(ctx context.Context) ([]string, error) {
 		return nil, m.listNetworksError
 	}
 	return m.networks, nil
+}
+
+func (m *mockDockerClient) ListComposeNetworks(ctx context.Context) ([]string, error) {
+	if m.listNetworksError != nil {
+		return nil, m.listNetworksError
+	}
+	return m.composeNetworks, nil
 }
 
 func (m *mockDockerClient) CreateNetwork(ctx context.Context, name string, labels map[string]string, opts ...dockercli.NetworkCreateOpts) error {

--- a/internal/planner/network_orphan_test.go
+++ b/internal/planner/network_orphan_test.go
@@ -1,0 +1,68 @@
+package planner
+
+import (
+	"sort"
+	"testing"
+)
+
+func set(names ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		m[n] = struct{}{}
+	}
+	return m
+}
+
+func TestOrphanNetworks(t *testing.T) {
+	tests := []struct {
+		name         string
+		existing     map[string]struct{}
+		desired      map[string]struct{}
+		composeOwned map[string]struct{}
+		want         []string
+	}{
+		{
+			name:         "compose-owned network is never an orphan",
+			existing:     set("app-net", "dockform-net"),
+			desired:      set("dockform-net"),
+			composeOwned: set("app-net"),
+			want:         nil,
+		},
+		{
+			name:         "dockform-managed network not desired is an orphan",
+			existing:     set("dockform-net", "old-net"),
+			desired:      set("dockform-net"),
+			composeOwned: set(),
+			want:         []string{"old-net"},
+		},
+		{
+			name:         "compose-owned excluded but real orphan still removed",
+			existing:     set("app-net", "old-net", "dockform-net"),
+			desired:      set("dockform-net"),
+			composeOwned: set("app-net"),
+			want:         []string{"old-net"},
+		},
+		{
+			name:         "all desired means no orphans",
+			existing:     set("a", "b"),
+			desired:      set("a", "b"),
+			composeOwned: set(),
+			want:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := orphanNetworks(tt.existing, tt.desired, tt.composeOwned)
+			sort.Strings(got)
+			if len(got) != len(tt.want) {
+				t.Fatalf("orphanNetworks = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("orphanNetworks = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/planner/prune.go
+++ b/internal/planner/prune.go
@@ -133,11 +133,19 @@ func (p *Planner) pruneContext(ctx context.Context, cfg manifest.Config, context
 	if err != nil {
 		errs = append(errs, apperr.Wrap("planner.pruneContext", apperr.External, err, "list managed networks for context %s", contextName))
 	} else {
+		// Compose-owned networks carry the identifier label but are managed by
+		// their stack's lifecycle, so they must not be pruned as orphans (GH #54).
+		composeOwned, err := p.getComposeOwnedNetworks(ctx, client)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		existing := make(map[string]struct{}, len(nets))
 		for _, n := range nets {
-			if _, want := desiredNetworks[n]; !want {
-				if err := client.RemoveNetwork(ctx, n); err != nil {
-					errs = append(errs, apperr.Wrap("planner.pruneContext", apperr.External, err, "remove unmanaged network %s in context %s", n, contextName))
-				}
+			existing[n] = struct{}{}
+		}
+		for _, n := range orphanNetworks(existing, desiredNetworks, composeOwned) {
+			if err := client.RemoveNetwork(ctx, n); err != nil {
+				errs = append(errs, apperr.Wrap("planner.pruneContext", apperr.External, err, "remove unmanaged network %s in context %s", n, contextName))
 			}
 		}
 	}

--- a/internal/planner/prune_test.go
+++ b/internal/planner/prune_test.go
@@ -88,3 +88,28 @@ func TestPlanner_Prune_RemovesOrphanedContainers(t *testing.T) {
 		t.Errorf("expected 1 container to be removed, got %d", len(mock.removedContainers))
 	}
 }
+
+// TestPlanner_Prune_PreservesComposeOwnedNetworks verifies that networks created
+// by a compose stack (carrying the identifier label but managed by the stack) are
+// not pruned as orphans, while genuinely unmanaged networks still are. Regression
+// test for GH #54.
+func TestPlanner_Prune_PreservesComposeOwnedNetworks(t *testing.T) {
+	mock := newMockDocker()
+	mock.networks = []string{"whoami", "stale-net"}
+	mock.composeNetworks = []string{"whoami"} // owned by a compose stack
+
+	p := NewWithDocker(mock)
+
+	cfg := manifest.Config{
+		Identifier: "test",
+		Contexts:   map[string]manifest.ContextConfig{"default": {}},
+	}
+
+	if err := p.Prune(context.Background(), cfg); err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+
+	if len(mock.removedNetworks) != 1 || mock.removedNetworks[0] != "stale-net" {
+		t.Errorf("expected only stale-net removed (compose-owned whoami preserved), got %v", mock.removedNetworks)
+	}
+}

--- a/test/e2e/compose_network_test.go
+++ b/test/e2e/compose_network_test.go
@@ -1,0 +1,72 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestComposeNetwork_NotOrphanedOnRepeatApply reproduces GH #54: a network defined
+// only in a compose file (not in dockform.yml) is created on first apply, then
+// must NOT be reported as "will be deleted" on subsequent plans/applies, and must
+// still exist afterwards.
+func TestComposeNetwork_NotOrphanedOnRepeatApply(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not found in PATH")
+	}
+
+	ctx := context.Background()
+	_ = logDockerContext(t)
+	if looksProd(t) && os.Getenv("E2E_ALLOW_HOST") != "1" {
+		t.Skip("refusing to run e2e against a production-looking daemon; set E2E_ALLOW_HOST=1 to override")
+	}
+
+	runID := uniqueID()
+	identifier := runID
+	ensureNetworkCreatableOrSkip(t, identifier)
+
+	netName := "df_e2e_" + runID + "_net"
+	bin := buildDockform(t)
+
+	t.Cleanup(func() {
+		cleanupByLabel(t, identifier)
+	})
+
+	tempDir := t.TempDir()
+	src := filepath.Join("testdata", "scenarios", "compose_network")
+	if err := copyTree(src, tempDir); err != nil {
+		t.Fatalf("copy scenario: %v", err)
+	}
+
+	env := append(os.Environ(), "DOCKFORM_RUN_ID="+runID)
+
+	// 1. FIRST APPLY: compose creates the network
+	if out, stderr, code := runCmdDetailed(t, tempDir, env, bin, "apply", "--skip-confirmation", "--manifest", tempDir); code != 0 {
+		t.Fatalf("first apply failed (code %d)\nSTDOUT:\n%s\nSTDERR:\n%s", code, out, stderr)
+	}
+
+	nets := dockerLines(t, ctx, "network", "ls", "--format", "{{.Name}}", "--filter", "label=io.dockform.identifier="+identifier)
+	if !contains(nets, netName) {
+		t.Fatalf("expected compose-defined network %q to exist after first apply, got %v", netName, nets)
+	}
+
+	// 2. SECOND PLAN: the compose network must not be flagged for deletion
+	planOut := runCmd(t, tempDir, env, bin, "plan", "--manifest", tempDir)
+	if strings.Contains(planOut, netName+" will be deleted") {
+		t.Fatalf("compose-defined network falsely marked for deletion on repeat plan:\n%s", planOut)
+	}
+
+	// 3. SECOND APPLY: must not destroy the network
+	if out, stderr, code := runCmdDetailed(t, tempDir, env, bin, "apply", "--skip-confirmation", "--manifest", tempDir); code != 0 {
+		t.Fatalf("second apply failed (code %d)\nSTDOUT:\n%s\nSTDERR:\n%s", code, out, stderr)
+	}
+
+	// 4. VERIFY: network still exists
+	netsAfter := dockerLines(t, ctx, "network", "ls", "--format", "{{.Name}}", "--filter", "label=io.dockform.identifier="+identifier)
+	if !contains(netsAfter, netName) {
+		t.Fatalf("expected compose-defined network %q to survive repeat apply, got %v", netName, netsAfter)
+	}
+}

--- a/test/e2e/testdata/scenarios/compose_network/docker-compose.yaml
+++ b/test/e2e/testdata/scenarios/compose_network/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  whoami:
+    image: alpine
+    command: ["sh", "-c", "sleep 5m"]
+    labels:
+      io.dockform.identifier: ${DOCKFORM_RUN_ID}
+    networks:
+      - internal
+
+# Network declared only here (not in dockform.yml). Compose creates it; dockform
+# injects its identifier label so destroy can find it. It must NOT be reported as
+# an orphan on a subsequent plan/apply (GH #54).
+networks:
+  internal:
+    name: df_e2e_${DOCKFORM_RUN_ID}_net

--- a/test/e2e/testdata/scenarios/compose_network/dockform.yml
+++ b/test/e2e/testdata/scenarios/compose_network/dockform.yml
@@ -1,0 +1,12 @@
+identifier: ${DOCKFORM_RUN_ID}
+
+contexts:
+  default: {}
+
+stacks:
+  default/app:
+    root: .
+    files:
+      - docker-compose.yaml
+    project:
+      name: df_e2e_${DOCKFORM_RUN_ID}


### PR DESCRIPTION
Fixes #54

If you define a network only in a compose file (not in dockform.yml), the first apply creates it fine, but every plan/apply after that says it'll be deleted. It usually isn't actually deleted (the running container still holds it, so the removal fails).