### PR TITLE
fix: show the full plan before the apply confirm prompt

### DIFF
--- a/internal/cli/applycmd/apply_test.go
+++ b/internal/cli/applycmd/apply_test.go
@@ -29,6 +29,38 @@ func TestApply_PrintsPlan_WhenRemovalsPresent(t *testing.T) {
 	}
 }
 
+// TestApply_PrintsFullPlanDetail_NotJustSummary guards dockform-ltv: apply must
+// print the full plan detail (section bodies) for review, not only the summary
+// line. Regression risk is re-routing the plan through the rolling-log TUI, which
+// clips tall plans and leaves only the trailing summary visible.
+func TestApply_PrintsFullPlanDetail_NotJustSummary(t *testing.T) {
+	defer clitest.WithStubDocker(t)()
+
+	root := cli.TestNewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetIn(strings.NewReader("no\n")) // decline so we only exercise the plan review
+	root.SetArgs([]string{"apply", "--manifest", clitest.BasicConfigPath(t)})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("apply execute: %v", err)
+	}
+	got := out.String()
+
+	// The summary line alone is not enough — the detail above it must be present.
+	if !strings.Contains(got, "Plan:") {
+		t.Fatalf("expected plan summary line; got: %s", got)
+	}
+	// Detail: at least one resource section body must be rendered alongside the summary.
+	hasDetail := strings.Contains(got, " will be deleted") ||
+		strings.Contains(got, " will be created") ||
+		strings.Contains(got, "up-to-date")
+	if !hasDetail {
+		t.Fatalf("expected full plan detail alongside summary, not just the summary line; got: %s", got)
+	}
+}
+
 func TestApply_NoRemovals_NoGuidance(t *testing.T) {
 	t.Helper()
 	undo := clitest.WithCustomDockerStub(t, `#!/bin/sh

--- a/internal/cli/applycmd/new.go
+++ b/internal/cli/applycmd/new.go
@@ -28,27 +28,30 @@ func New() *cobra.Command {
 				ctx.Planner = ctx.Planner.WithParallel(false)
 			}
 
-			// Build the plan with rolling logs (or direct when verbose)
+			// Build the plan with rolling logs (or direct when verbose). The rolling
+			// log shows BuildPlan progress only — we deliberately do not hand it the
+			// plan as its final report, because the TUI renders inline and clips a
+			// tall plan to the terminal height, hiding creates/destroys before the
+			// confirm prompt (dockform-ltv). The full plan is printed below instead.
 			var builtPlan *planner.Plan
 			verbose, _ := cmd.Flags().GetBool("verbose")
-			planOut, usedTUI, err := common.RunWithRollingOrDirect(cmd, verbose, func(runCtx context.Context) (string, error) {
-				var s string
-				err := ctx.WithRunContext(runCtx, func() error {
+			_, _, err = common.RunWithRollingOrDirect(cmd, verbose, func(runCtx context.Context) (string, error) {
+				return "", ctx.WithRunContext(runCtx, func() error {
 					plan, err := ctx.BuildPlan()
 					if err != nil {
 						return err
 					}
 					builtPlan = plan
-					s = plan.String()
 					return nil
 				})
-				return s, err
 			})
 			if err != nil {
 				return err
 			}
-			if !usedTUI {
-				ctx.Printer.Plain("%s", planOut)
+			// Print the full plan for review. Goes through the normal printer so it
+			// scrolls naturally instead of being clipped by the rolling-log TUI.
+			if builtPlan != nil {
+				ctx.Printer.Plain("%s", builtPlan.String())
 			}
 
 			// If the plan has no create/update/delete actions, inform and exit early


### PR DESCRIPTION
`apply` was rendering the plan through the rollinglog TUI, which draws inline and clips to terminal height. On any plan taller than the terminal, the top scrolled off, so the Volumes and Networks sections were not shown.

The rolling log now shows `BuildPlan` progress only, the full plan is printed via the normal printer just like `plan` and `destroy`