### PR TITLE
feat: warn on unanchored tag_pattern in images check

### DIFF
--- a/internal/cli/imagescmd/check.go
+++ b/internal/cli/imagescmd/check.go
@@ -24,6 +24,38 @@ import (
 // is only checked for digest drift.
 const tagPatternLabel = "dockform.tag_pattern"
 
+// tagPatternIssue flags a service whose tag_pattern is set but not anchored with
+// a trailing '$'. This is the visible symptom of writing a lone '$' in the
+// compose label: Docker Compose interpolation consumes it (it needs '$$' for a
+// literal '$'), so dockform receives an unanchored pattern that silently matches
+// unintended tags.
+type tagPatternIssue struct {
+	stack   string
+	service string
+	pattern string
+}
+
+// unanchoredTagPatterns returns, sorted by stack then service, the services whose
+// tag_pattern is non-empty and does not end with '$'. These are likely cases of a
+// lone '$' being eaten by Compose interpolation (it needs '$$').
+func unanchoredTagPatterns(inputs []images.CheckInput) []tagPatternIssue {
+	var issues []tagPatternIssue
+	for _, in := range inputs {
+		for name, spec := range in.Services {
+			if spec.TagPattern != "" && !strings.HasSuffix(spec.TagPattern, "$") {
+				issues = append(issues, tagPatternIssue{stack: in.StackKey, service: name, pattern: spec.TagPattern})
+			}
+		}
+	}
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].stack != issues[j].stack {
+			return issues[i].stack < issues[j].stack
+		}
+		return issues[i].service < issues[j].service
+	})
+	return issues
+}
+
 func newCheckCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check [service...]",
@@ -105,6 +137,15 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	// Warn about tag_pattern labels that look mis-escaped: a lone '$' in a compose
+	// label is consumed by Compose interpolation (needs '$$'), leaving the pattern
+	// unanchored so it silently matches unintended tags. Warnings go to stderr so
+	// they don't corrupt --json output on stdout.
+	for _, issue := range unanchoredTagPatterns(inputs) {
+		pr.Warn("tag_pattern for %s/%s (%q) is not anchored with '$'; Compose needs '$$' for a literal '$' (a lone '$' is consumed). If intentional, ignore. See https://docs.docker.com/reference/compose-file/interpolation/",
+			issue.stack, issue.service, issue.pattern)
 	}
 
 	// Render output.

--- a/internal/cli/imagescmd/tag_pattern_warn_test.go
+++ b/internal/cli/imagescmd/tag_pattern_warn_test.go
@@ -1,0 +1,60 @@
+package imagescmd
+
+import (
+	"testing"
+
+	"github.com/gcstr/dockform/internal/images"
+)
+
+func TestUnanchoredTagPatterns(t *testing.T) {
+	inputs := []images.CheckInput{
+		{
+			StackKey: "ctx/backup",
+			Services: map[string]images.ServiceSpec{
+				// Unanchored: lone '$' was eaten by Compose -> flagged.
+				"db": {Image: "postgres:16", TagPattern: `^v\d+\.\d+\.\d+`},
+				// Properly anchored ($$ -> $) -> not flagged.
+				"app": {Image: "app:1", TagPattern: `^v\d+\.\d+\.\d+$`},
+			},
+		},
+		{
+			StackKey: "ctx/web",
+			Services: map[string]images.ServiceSpec{
+				// Digest-only (no pattern) -> not flagged.
+				"nginx": {Image: "nginx:1"},
+				// Unanchored -> flagged.
+				"api": {Image: "api:2", TagPattern: `^\d+`},
+			},
+		},
+	}
+
+	got := unanchoredTagPatterns(inputs)
+
+	want := []tagPatternIssue{
+		{stack: "ctx/backup", service: "db", pattern: `^v\d+\.\d+\.\d+`},
+		{stack: "ctx/web", service: "api", pattern: `^\d+`},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d issues, got %d: %+v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("issue %d = %+v, want %+v (full: %+v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestUnanchoredTagPatterns_NoneWhenAllAnchoredOrEmpty(t *testing.T) {
+	inputs := []images.CheckInput{
+		{
+			StackKey: "ctx/a",
+			Services: map[string]images.ServiceSpec{
+				"anchored": {Image: "x:1", TagPattern: `^v\d+$`},
+				"none":     {Image: "y:1", TagPattern: ""},
+			},
+		},
+	}
+	if got := unanchoredTagPatterns(inputs); len(got) != 0 {
+		t.Fatalf("expected no issues, got %+v", got)
+	}
+}


### PR DESCRIPTION
`dockform images check` now warns when a service's `dockform.tag_pattern` is set but isn't anchored with a trailing `$` 

```
! tag_pattern for services/backup ("^v\d+\.\d+\.\d+") is not anchored with '$';
  Compose needs '$$' for a literal '$' (a lone '$' is consumed). If intentional,
  ignore. See https://docs.docker.com/reference/compose-file/interpolation/  

