### PR TITLE
feat: changes only output

### DIFF
--- a/internal/cli/applycmd/long_flag_test.go
+++ b/internal/cli/applycmd/long_flag_test.go
@@ -1,0 +1,128 @@
+package applycmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gcstr/dockform/internal/cli"
+	"github.com/gcstr/dockform/internal/cli/clitest"
+)
+
+// applyUpToDateDockerStub mirrors the plancmd stub: nginx is running and
+// up-to-date (hash matches) but orphan-vol needs deletion.
+// Provides an apply-phase response for volume rm as well.
+const applyUpToDateDockerStub = `#!/bin/sh
+cmd="$1"; shift
+case "$cmd" in
+  version)
+    exit 0 ;;
+  volume)
+    sub="$1"; shift
+    if [ "$sub" = "ls" ]; then echo "orphan-vol"; exit 0; fi
+    if [ "$sub" = "rm" ]; then exit 0; fi ;;
+  network)
+    sub="$1"; shift
+    if [ "$sub" = "ls" ]; then exit 0; fi ;;
+  compose)
+    for a in "$@"; do [ "$a" = "--services" ] && { echo "nginx"; exit 0; }; done
+    prev=""
+    for a in "$@"; do
+      if [ "$prev" = "--hash" ]; then echo "nginx deadbeef"; exit 0; fi
+      prev="$a"
+    done
+    saw_ps=0; saw_format=0; saw_json=0
+    for a in "$@"; do
+      [ "$a" = "ps" ] && saw_ps=1
+      [ "$a" = "--format" ] && saw_format=1
+      [ "$a" = "json" ] && saw_json=1
+    done
+    if [ "$saw_ps" = "1" ] && [ "$saw_format" = "1" ] && [ "$saw_json" = "1" ]; then
+      printf '[{"Name":"website_nginx_1","Service":"nginx","State":"running","Image":"nginx","Project":"website","Publishers":[]}]\n'
+      exit 0
+    fi
+    exit 0 ;;
+  inspect)
+    fmt_arg=""
+    first_container=""
+    skip_next=0
+    for a in "$@"; do
+      if [ "$skip_next" = "1" ]; then
+        skip_next=0
+        fmt_arg="$a"
+        continue
+      fi
+      if [ "$a" = "-f" ]; then
+        skip_next=1
+        continue
+      fi
+      if [ -z "$first_container" ] && [ "${a#-}" = "$a" ]; then
+        first_container="$a"
+      fi
+    done
+    labels='{"com.docker.compose.config-hash":"deadbeef","io.dockform.identifier":"demo"}'
+    case "$fmt_arg" in
+      *Name*tab*)
+        echo "${first_container}	${labels}" ;;
+      *)
+        echo "$labels" ;;
+    esac
+    exit 0 ;;
+  ps)
+    exit 0 ;;
+esac
+exit 0
+`
+
+// TestApply_DefaultChangesOnly verifies that the apply plan review output omits
+// no-op lines in the default (changes-only) mode.
+func TestApply_DefaultChangesOnly(t *testing.T) {
+	t.Helper()
+	undo := clitest.WithCustomDockerStub(t, applyUpToDateDockerStub)
+	defer undo()
+
+	root := cli.TestNewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetIn(strings.NewReader("no\n")) // decline — only test the plan review
+	root.SetArgs([]string{"apply", "--manifest", clitest.BasicConfigPath(t)})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("apply execute: %v", err)
+	}
+	got := out.String()
+
+	// Default (changes-only) must NOT show per-service no-op line.
+	if strings.Contains(got, "up-to-date") {
+		t.Fatalf("default apply output should omit 'up-to-date' lines; got: %s", got)
+	}
+	// It should still show a changed resource (the orphan-vol deletion).
+	if !strings.Contains(got, "unchanged") && !strings.Contains(got, "No changes") {
+		t.Fatalf("expected 'unchanged' or 'No changes' in default apply output; got: %s", got)
+	}
+}
+
+// TestApply_LongShowsNoOpLines verifies that --long produces "up-to-date" lines
+// in the plan review that are absent from the default changes-only output.
+func TestApply_LongShowsNoOpLines(t *testing.T) {
+	t.Helper()
+	undo := clitest.WithCustomDockerStub(t, applyUpToDateDockerStub)
+	defer undo()
+
+	root := cli.TestNewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetIn(strings.NewReader("no\n")) // decline — only test the plan review
+	root.SetArgs([]string{"apply", "--long", "--manifest", clitest.BasicConfigPath(t)})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("apply --long execute: %v", err)
+	}
+	got := out.String()
+
+	if !strings.Contains(got, "up-to-date") {
+		t.Fatalf("expected 'up-to-date' lines in --long apply output; got: %s", got)
+	}
+}

--- a/internal/cli/applycmd/long_flag_test.go
+++ b/internal/cli/applycmd/long_flag_test.go
@@ -77,7 +77,6 @@ exit 0
 // TestApply_DefaultChangesOnly verifies that the apply plan review output omits
 // no-op lines in the default (changes-only) mode.
 func TestApply_DefaultChangesOnly(t *testing.T) {
-	t.Helper()
 	undo := clitest.WithCustomDockerStub(t, applyUpToDateDockerStub)
 	defer undo()
 
@@ -106,7 +105,6 @@ func TestApply_DefaultChangesOnly(t *testing.T) {
 // TestApply_LongShowsNoOpLines verifies that --long produces "up-to-date" lines
 // in the plan review that are absent from the default changes-only output.
 func TestApply_LongShowsNoOpLines(t *testing.T) {
-	t.Helper()
 	undo := clitest.WithCustomDockerStub(t, applyUpToDateDockerStub)
 	defer undo()
 

--- a/internal/cli/applycmd/new.go
+++ b/internal/cli/applycmd/new.go
@@ -49,20 +49,22 @@ func New() *cobra.Command {
 				return err
 			}
 			long, _ := cmd.Flags().GetBool("long")
-			// Print the plan for review. Goes through the normal printer so it
-			// scrolls naturally instead of being clipped by the rolling-log TUI.
-			// --long shows all resources including no-ops; default is changes-only.
-			if builtPlan != nil {
-				ctx.Printer.Plain("%s", builtPlan.Render(planner.PlanRenderOptions{Full: long}))
-			}
 
 			// If the plan has no create/update/delete actions, inform and exit early
+			// (before the review render, so we don't print both "No changes…" and this).
 			if builtPlan != nil && builtPlan.Resources != nil {
 				createCount, updateCount, deleteCount := builtPlan.Resources.CountActions()
 				if createCount == 0 && updateCount == 0 && deleteCount == 0 {
 					ctx.Printer.Plain("Nothing to apply. Exiting.")
 					return nil
 				}
+			}
+
+			// Print the plan for review. Goes through the normal printer so it
+			// scrolls naturally instead of being clipped by the rolling-log TUI.
+			// --long shows all resources including no-ops; default is changes-only.
+			if builtPlan != nil {
+				ctx.Printer.Plain("%s", builtPlan.Render(planner.PlanRenderOptions{Full: long}))
 			}
 
 			// Get confirmation from user

--- a/internal/cli/applycmd/new.go
+++ b/internal/cli/applycmd/new.go
@@ -48,10 +48,12 @@ func New() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// Print the full plan for review. Goes through the normal printer so it
+			long, _ := cmd.Flags().GetBool("long")
+			// Print the plan for review. Goes through the normal printer so it
 			// scrolls naturally instead of being clipped by the rolling-log TUI.
+			// --long shows all resources including no-ops; default is changes-only.
 			if builtPlan != nil {
-				ctx.Printer.Plain("%s", builtPlan.String())
+				ctx.Printer.Plain("%s", builtPlan.Render(planner.PlanRenderOptions{Full: long}))
 			}
 
 			// If the plan has no create/update/delete actions, inform and exit early
@@ -105,6 +107,7 @@ func New() *cobra.Command {
 	}
 	cmd.Flags().Bool("skip-confirmation", false, "Skip confirmation prompt and apply immediately")
 	cmd.Flags().Bool("sequential", false, "Use sequential processing instead of the default parallel processing (slower but uses less CPU and Docker daemon resources)")
+	cmd.Flags().Bool("long", false, "Show the full plan including unchanged resources")
 	cmd.Flags().Bool("strict-prune", false, "Fail apply when prune operations encounter errors")
 	cmd.Flags().Bool("verbose-prune-errors", false, "Print detailed prune error details when not using --strict-prune")
 	common.AddTargetFlags(cmd)

--- a/internal/cli/plancmd/long_flag_test.go
+++ b/internal/cli/plancmd/long_flag_test.go
@@ -1,0 +1,138 @@
+package plancmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gcstr/dockform/internal/cli"
+	"github.com/gcstr/dockform/internal/cli/clitest"
+)
+
+// upToDateDockerStub is a docker stub where the nginx service is running and
+// up-to-date (hash matches), but there is an orphan volume that will be deleted.
+// This produces a plan with at least one change (delete orphan-vol) and at
+// least one no-op (nginx up-to-date).
+const upToDateDockerStub = `#!/bin/sh
+cmd="$1"; shift
+case "$cmd" in
+  version)
+    exit 0 ;;
+  volume)
+    sub="$1"; shift
+    if [ "$sub" = "ls" ]; then echo "orphan-vol"; exit 0; fi ;;
+  network)
+    sub="$1"; shift
+    if [ "$sub" = "ls" ]; then exit 0; fi ;;
+  compose)
+    for a in "$@"; do [ "$a" = "--services" ] && { echo "nginx"; exit 0; }; done
+    prev=""
+    for a in "$@"; do
+      if [ "$prev" = "--hash" ]; then echo "nginx deadbeef"; exit 0; fi
+      prev="$a"
+    done
+    saw_ps=0; saw_format=0; saw_json=0
+    for a in "$@"; do
+      [ "$a" = "ps" ] && saw_ps=1
+      [ "$a" = "--format" ] && saw_format=1
+      [ "$a" = "json" ] && saw_json=1
+    done
+    if [ "$saw_ps" = "1" ] && [ "$saw_format" = "1" ] && [ "$saw_json" = "1" ]; then
+      printf '[{"Name":"website_nginx_1","Service":"nginx","State":"running","Image":"nginx","Project":"website","Publishers":[]}]\n'
+      exit 0
+    fi
+    exit 0 ;;
+  inspect)
+    # Handle both single-label ({{json .Config.Labels}}) and
+    # multi-label ({{.Name}}\t{{json .Config.Labels}}) format strings.
+    for a in "$@"; do
+      case "$a" in
+        *Name*tab*) ;;  # ignored sentinel
+      esac
+    done
+    # The -f flag is $1 (already shifted off cmd). Remaining args include
+    # the format string then container names. We respond with the appropriate
+    # label JSON regardless of format variant — the caller parses what it needs.
+    fmt_arg=""
+    first_container=""
+    skip_next=0
+    for a in "$@"; do
+      if [ "$skip_next" = "1" ]; then
+        skip_next=0
+        fmt_arg="$a"
+        continue
+      fi
+      if [ "$a" = "-f" ]; then
+        skip_next=1
+        continue
+      fi
+      if [ -z "$first_container" ] && [ "${a#-}" = "$a" ]; then
+        first_container="$a"
+      fi
+    done
+    labels='{"com.docker.compose.config-hash":"deadbeef","io.dockform.identifier":"demo"}'
+    case "$fmt_arg" in
+      *Name*tab*)
+        # Multi-container format: "{{.Name}}\t{{json .Config.Labels}}"
+        echo "${first_container}	${labels}" ;;
+      *)
+        # Single-container format: "{{json .Config.Labels}}"
+        echo "$labels" ;;
+    esac
+    exit 0 ;;
+  ps)
+    exit 0 ;;
+esac
+exit 0
+`
+
+// TestPlan_DefaultChangesOnly verifies that the default plan output omits
+// no-op lines (like "up-to-date") and instead shows an "unchanged" summary.
+func TestPlan_DefaultChangesOnly(t *testing.T) {
+	t.Helper()
+	undo := clitest.WithCustomDockerStub(t, upToDateDockerStub)
+	defer undo()
+
+	root := cli.TestNewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"plan", "--manifest", clitest.BasicConfigPath(t)})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("plan execute: %v", err)
+	}
+	got := out.String()
+
+	// Default (changes-only) must NOT show the per-service no-op line.
+	if strings.Contains(got, "up-to-date") {
+		t.Fatalf("default output should omit 'up-to-date' lines; got: %s", got)
+	}
+	// It should mention how many resources are unchanged.
+	if !strings.Contains(got, "unchanged") && !strings.Contains(got, "No changes") {
+		t.Fatalf("expected 'unchanged' or 'No changes' in default output; got: %s", got)
+	}
+}
+
+// TestPlan_LongShowsNoOpLines verifies that --long produces "up-to-date" lines
+// that are absent from the default changes-only output.
+func TestPlan_LongShowsNoOpLines(t *testing.T) {
+	t.Helper()
+	undo := clitest.WithCustomDockerStub(t, upToDateDockerStub)
+	defer undo()
+
+	root := cli.TestNewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"plan", "--long", "--manifest", clitest.BasicConfigPath(t)})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("plan --long execute: %v", err)
+	}
+	got := out.String()
+
+	if !strings.Contains(got, "up-to-date") {
+		t.Fatalf("expected 'up-to-date' lines in --long output; got: %s", got)
+	}
+}

--- a/internal/cli/plancmd/long_flag_test.go
+++ b/internal/cli/plancmd/long_flag_test.go
@@ -89,7 +89,6 @@ exit 0
 // TestPlan_DefaultChangesOnly verifies that the default plan output omits
 // no-op lines (like "up-to-date") and instead shows an "unchanged" summary.
 func TestPlan_DefaultChangesOnly(t *testing.T) {
-	t.Helper()
 	undo := clitest.WithCustomDockerStub(t, upToDateDockerStub)
 	defer undo()
 
@@ -117,7 +116,6 @@ func TestPlan_DefaultChangesOnly(t *testing.T) {
 // TestPlan_LongShowsNoOpLines verifies that --long produces "up-to-date" lines
 // that are absent from the default changes-only output.
 func TestPlan_LongShowsNoOpLines(t *testing.T) {
-	t.Helper()
 	undo := clitest.WithCustomDockerStub(t, upToDateDockerStub)
 	defer undo()
 

--- a/internal/cli/plancmd/new.go
+++ b/internal/cli/plancmd/new.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/gcstr/dockform/internal/cli/common"
+	"github.com/gcstr/dockform/internal/planner"
 	"github.com/gcstr/dockform/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -26,6 +27,9 @@ func New() *cobra.Command {
 				ctx.Planner = ctx.Planner.WithParallel(false)
 			}
 
+			long, _ := cmd.Flags().GetBool("long")
+			renderOpts := planner.PlanRenderOptions{Full: long}
+
 			// Build plan normally
 			verbose, _ := cmd.Flags().GetBool("verbose")
 			if verbose {
@@ -33,7 +37,7 @@ func New() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				ctx.Printer.Plain("%s", plan.String())
+				ctx.Printer.Plain("%s", plan.Render(renderOpts))
 			} else {
 				var out string
 				_, err = ui.RunWithRollingLog(cmd.Context(), func(runCtx context.Context) (string, error) {
@@ -53,7 +57,7 @@ func New() *cobra.Command {
 							return runCtx.Err()
 						}
 
-						out = plan.String()
+						out = plan.Render(renderOpts)
 						return nil
 					})
 				})
@@ -68,6 +72,9 @@ func New() *cobra.Command {
 
 	// Add sequential flag
 	cmd.Flags().Bool("sequential", false, "Use sequential processing instead of the default parallel processing (slower but uses less CPU and Docker daemon resources)")
+
+	// Add long flag
+	cmd.Flags().Bool("long", false, "Show the full plan including unchanged resources")
 
 	// Add targeting flags
 	common.AddTargetFlags(cmd)

--- a/internal/planner/resource.go
+++ b/internal/planner/resource.go
@@ -391,13 +391,10 @@ func renderResourcePlanChangesOnly(rp *ResourcePlan) string {
 				}
 			}
 
-			cap := filesetChangedFileCap
-			if cap > len(changedFiles) {
-				cap = len(changedFiles)
-			}
+			show := min(filesetChangedFileCap, len(changedFiles))
 
 			var diffLines []ui.DiffLine
-			for _, item := range changedFiles[:cap] {
+			for _, item := range changedFiles[:show] {
 				diffLines = append(diffLines, formatFilesetItem(item))
 			}
 

--- a/internal/planner/resource.go
+++ b/internal/planner/resource.go
@@ -109,6 +109,10 @@ func (r Resource) FormatAction() string {
 	}
 }
 
+// filesetChangedFileCap is the maximum number of changed file lines shown per
+// fileset in changes-only mode before the remainder is summarised.
+const filesetChangedFileCap = 10
+
 // PlanRenderOptions controls how a ResourcePlan is rendered.
 type PlanRenderOptions struct {
 	// Full renders all resources including no-ops. When false (changes-only mode,
@@ -264,6 +268,33 @@ func appendPlanSummary(result string, rp *ResourcePlan) string {
 	return result
 }
 
+// formatFilesetItem formats a single non-noop fileset item into a DiffLine,
+// using the same logic as the full renderer's fileset loop.
+func formatFilesetItem(res Resource) ui.DiffLine {
+	var msg string
+	if res.Name != "" {
+		msg = fmt.Sprintf("%s %s", res.Action, ui.Italic(res.Name))
+	} else {
+		msg = res.FormatAction()
+	}
+	return ui.DiffLine{Type: res.ChangeType, Message: msg}
+}
+
+// summarizeFileActions counts creates, updates, and deletes in a slice of Resources.
+func summarizeFileActions(rs []Resource) (create, update, delete int) {
+	for _, r := range rs {
+		switch r.Action {
+		case ActionCreate:
+			create++
+		case ActionUpdate, ActionReconcile:
+			update++
+		case ActionDelete:
+			delete++
+		}
+	}
+	return
+}
+
 // countNoop returns the number of resources with ActionNoop.
 func countNoop(rs []Resource) int {
 	n := 0
@@ -277,7 +308,6 @@ func countNoop(rs []Resource) int {
 
 // renderResourcePlanChangesOnly renders only changed resources, with a footer
 // count of unchanged (no-op) resources per section.
-// Stacks and Filesets changes-only rendering added in a later task.
 func renderResourcePlanChangesOnly(rp *ResourcePlan) string {
 	var sections []ui.NestedSection
 
@@ -302,6 +332,95 @@ func renderResourcePlanChangesOnly(rp *ResourcePlan) string {
 
 	buildFlatSection("Volumes", rp.Volumes)
 	buildFlatSection("Networks", rp.Networks)
+
+	// Stacks section (changes-only)
+	if len(rp.Stacks) > 0 {
+		stackNames := make([]string, 0, len(rp.Stacks))
+		for name := range rp.Stacks {
+			stackNames = append(stackNames, name)
+		}
+		sort.Strings(stackNames)
+
+		var changedStackSections []ui.NestedSection
+		unchangedServices := 0
+
+		for _, stackName := range stackNames {
+			services := rp.Stacks[stackName]
+			unchangedServices += countNoop(services)
+
+			var items []ui.DiffLine
+			for _, svc := range services {
+				if svc.Action != ActionNoop {
+					items = append(items, formatResourceLine(svc))
+				}
+			}
+			if len(items) > 0 {
+				changedStackSections = append(changedStackSections, ui.NestedSection{Title: stackName, Items: items})
+			}
+		}
+
+		stacksSec := ui.NestedSection{Title: "Stacks", Sections: changedStackSections}
+		if unchangedServices > 0 {
+			stacksSec.Footer = []ui.DiffLine{{Type: ui.Info, Message: fmt.Sprintf("%d unchanged", unchangedServices)}}
+		}
+		sections = append(sections, stacksSec)
+	}
+
+	// Filesets section (changes-only)
+	if len(rp.Filesets) > 0 {
+		filesetNames := make([]string, 0, len(rp.Filesets))
+		for name := range rp.Filesets {
+			filesetNames = append(filesetNames, name)
+		}
+		sort.Strings(filesetNames)
+
+		var changedFilesetSections []ui.NestedSection
+		unchangedFilesets := 0
+
+		for _, filesetName := range filesetNames {
+			items := rp.Filesets[filesetName]
+			if countNoop(items) == len(items) {
+				unchangedFilesets++
+				continue
+			}
+
+			var changedFiles []Resource
+			for _, item := range items {
+				if item.Action != ActionNoop {
+					changedFiles = append(changedFiles, item)
+				}
+			}
+
+			cap := filesetChangedFileCap
+			if cap > len(changedFiles) {
+				cap = len(changedFiles)
+			}
+
+			var diffLines []ui.DiffLine
+			for _, item := range changedFiles[:cap] {
+				diffLines = append(diffLines, formatFilesetItem(item))
+			}
+
+			if len(changedFiles) > filesetChangedFileCap {
+				remaining := changedFiles[filesetChangedFileCap:]
+				extra := len(remaining)
+				c, u, d := summarizeFileActions(remaining)
+				diffLines = append(diffLines, ui.DiffLine{
+					Type:    ui.Info,
+					Message: fmt.Sprintf("… and %d more changed (%d created, %d updated, %d deleted)", extra, c, u, d),
+				})
+			}
+
+			changedFilesetSections = append(changedFilesetSections, ui.NestedSection{Title: filesetName, Items: diffLines})
+		}
+
+		filesetsSec := ui.NestedSection{Title: "Filesets", Sections: changedFilesetSections}
+		if unchangedFilesets > 0 {
+			filesetsSec.Footer = []ui.DiffLine{{Type: ui.Info, Message: fmt.Sprintf("%d unchanged", unchangedFilesets)}}
+		}
+		sections = append(sections, filesetsSec)
+	}
+
 	buildFlatSection("Containers", rp.Containers)
 
 	return appendPlanSummary(ui.RenderNestedSections(sections), rp)

--- a/internal/planner/resource.go
+++ b/internal/planner/resource.go
@@ -109,8 +109,27 @@ func (r Resource) FormatAction() string {
 	}
 }
 
-// RenderResourcePlan renders a ResourcePlan with consistent formatting
+// PlanRenderOptions controls how a ResourcePlan is rendered.
+type PlanRenderOptions struct {
+	// Full renders all resources including no-ops. When false (changes-only mode,
+	// wired in a later task) only resources with actions are shown.
+	Full bool
+}
+
+// RenderResourcePlanOpts renders a ResourcePlan according to opts.
+func RenderResourcePlanOpts(rp *ResourcePlan, opts PlanRenderOptions) string {
+	// opts consumed in later tasks
+	_ = opts.Full
+	return renderResourcePlanFull(rp)
+}
+
+// RenderResourcePlan renders a ResourcePlan with consistent formatting.
+// It is equivalent to RenderResourcePlanOpts with Full: true.
 func RenderResourcePlan(rp *ResourcePlan) string {
+	return RenderResourcePlanOpts(rp, PlanRenderOptions{Full: true})
+}
+
+func renderResourcePlanFull(rp *ResourcePlan) string {
 	var sections []ui.NestedSection
 
 	// Volumes section

--- a/internal/planner/resource.go
+++ b/internal/planner/resource.go
@@ -137,9 +137,7 @@ func renderResourcePlanFull(rp *ResourcePlan) string {
 	if len(rp.Volumes) > 0 {
 		var items []ui.DiffLine
 		for _, res := range rp.Volumes {
-			name := ui.Italic(res.Name)
-			msg := fmt.Sprintf("%s %s", name, res.FormatAction())
-			items = append(items, ui.DiffLine{Type: res.ChangeType, Message: msg})
+			items = append(items, formatResourceLine(res))
 		}
 		sections = append(sections, ui.NestedSection{Title: "Volumes", Items: items})
 	}
@@ -148,9 +146,7 @@ func renderResourcePlanFull(rp *ResourcePlan) string {
 	if len(rp.Networks) > 0 {
 		var items []ui.DiffLine
 		for _, res := range rp.Networks {
-			name := ui.Italic(res.Name)
-			msg := fmt.Sprintf("%s %s", name, res.FormatAction())
-			items = append(items, ui.DiffLine{Type: res.ChangeType, Message: msg})
+			items = append(items, formatResourceLine(res))
 		}
 		sections = append(sections, ui.NestedSection{Title: "Networks", Items: items})
 	}
@@ -171,10 +167,7 @@ func renderResourcePlanFull(rp *ResourcePlan) string {
 			var items []ui.DiffLine
 
 			for _, res := range services {
-				// For services, we don't repeat the stack name since it's in the section title
-				name := ui.Italic(res.Name)
-				msg := fmt.Sprintf("%s %s", name, res.FormatAction())
-				items = append(items, ui.DiffLine{Type: res.ChangeType, Message: msg})
+				items = append(items, formatResourceLine(res))
 			}
 
 			if len(items) > 0 {
@@ -240,27 +233,34 @@ func renderResourcePlanFull(rp *ResourcePlan) string {
 	if len(rp.Containers) > 0 {
 		var items []ui.DiffLine
 		for _, res := range rp.Containers {
-			name := ui.Italic(res.Name)
-			msg := fmt.Sprintf("%s %s", name, res.FormatAction())
-			items = append(items, ui.DiffLine{Type: res.ChangeType, Message: msg})
+			items = append(items, formatResourceLine(res))
 		}
 		sections = append(sections, ui.NestedSection{Title: "Containers", Items: items})
 	}
 
-	// Calculate summary counts
-	createCount, updateCount, deleteCount := rp.CountActions()
+	return appendPlanSummary(ui.RenderNestedSections(sections), rp)
+}
 
-	// Render sections
-	result := ui.RenderNestedSections(sections)
+// formatResourceLine returns a DiffLine for a resource using the standard
+// "italic-name action-text" format used by Volumes, Networks, Containers, and
+// Stacks flat items.
+func formatResourceLine(res Resource) ui.DiffLine {
+	return ui.DiffLine{
+		Type:    res.ChangeType,
+		Message: fmt.Sprintf("%s %s", ui.Italic(res.Name), res.FormatAction()),
+	}
+}
 
-	// Add summary line
-	if createCount > 0 || updateCount > 0 || deleteCount > 0 {
+// appendPlanSummary appends a plan summary line to result when there are any
+// creates, updates, or deletes.
+func appendPlanSummary(result string, rp *ResourcePlan) string {
+	create, update, delete := rp.CountActions()
+	if create > 0 || update > 0 || delete > 0 {
 		if result != "" {
 			result += "\n"
 		}
-		result += ui.FormatPlanSummary(createCount, updateCount, deleteCount)
+		result += ui.FormatPlanSummary(create, update, delete)
 	}
-
 	return result
 }
 
@@ -290,9 +290,7 @@ func renderResourcePlanChangesOnly(rp *ResourcePlan) string {
 			if res.Action == ActionNoop {
 				continue
 			}
-			name := ui.Italic(res.Name)
-			msg := fmt.Sprintf("%s %s", name, res.FormatAction())
-			items = append(items, ui.DiffLine{Type: res.ChangeType, Message: msg})
+			items = append(items, formatResourceLine(res))
 		}
 		sec := ui.NestedSection{Title: title, Items: items}
 		noop := countNoop(resources)
@@ -306,17 +304,7 @@ func renderResourcePlanChangesOnly(rp *ResourcePlan) string {
 	buildFlatSection("Networks", rp.Networks)
 	buildFlatSection("Containers", rp.Containers)
 
-	result := ui.RenderNestedSections(sections)
-
-	create, update, delete := rp.CountActions()
-	if create > 0 || update > 0 || delete > 0 {
-		if result != "" {
-			result += "\n"
-		}
-		result += ui.FormatPlanSummary(create, update, delete)
-	}
-
-	return result
+	return appendPlanSummary(ui.RenderNestedSections(sections), rp)
 }
 
 // CountActions counts the number of each action type in the plan

--- a/internal/planner/resource.go
+++ b/internal/planner/resource.go
@@ -118,9 +118,10 @@ type PlanRenderOptions struct {
 
 // RenderResourcePlanOpts renders a ResourcePlan according to opts.
 func RenderResourcePlanOpts(rp *ResourcePlan, opts PlanRenderOptions) string {
-	// opts consumed in later tasks
-	_ = opts.Full
-	return renderResourcePlanFull(rp)
+	if opts.Full {
+		return renderResourcePlanFull(rp)
+	}
+	return renderResourcePlanChangesOnly(rp)
 }
 
 // RenderResourcePlan renders a ResourcePlan with consistent formatting.
@@ -258,6 +259,61 @@ func renderResourcePlanFull(rp *ResourcePlan) string {
 			result += "\n"
 		}
 		result += ui.FormatPlanSummary(createCount, updateCount, deleteCount)
+	}
+
+	return result
+}
+
+// countNoop returns the number of resources with ActionNoop.
+func countNoop(rs []Resource) int {
+	n := 0
+	for _, r := range rs {
+		if r.Action == ActionNoop {
+			n++
+		}
+	}
+	return n
+}
+
+// renderResourcePlanChangesOnly renders only changed resources, with a footer
+// count of unchanged (no-op) resources per section.
+// Stacks and Filesets changes-only rendering added in a later task.
+func renderResourcePlanChangesOnly(rp *ResourcePlan) string {
+	var sections []ui.NestedSection
+
+	buildFlatSection := func(title string, resources []Resource) {
+		if len(resources) == 0 {
+			return
+		}
+		var items []ui.DiffLine
+		for _, res := range resources {
+			if res.Action == ActionNoop {
+				continue
+			}
+			name := ui.Italic(res.Name)
+			msg := fmt.Sprintf("%s %s", name, res.FormatAction())
+			items = append(items, ui.DiffLine{Type: res.ChangeType, Message: msg})
+		}
+		sec := ui.NestedSection{Title: title, Items: items}
+		noop := countNoop(resources)
+		if noop > 0 {
+			sec.Footer = []ui.DiffLine{{Type: ui.Info, Message: fmt.Sprintf("%d unchanged", noop)}}
+		}
+		sections = append(sections, sec)
+	}
+
+	buildFlatSection("Volumes", rp.Volumes)
+	buildFlatSection("Networks", rp.Networks)
+	buildFlatSection("Containers", rp.Containers)
+
+	result := ui.RenderNestedSections(sections)
+
+	create, update, delete := rp.CountActions()
+	if create > 0 || update > 0 || delete > 0 {
+		if result != "" {
+			result += "\n"
+		}
+		result += ui.FormatPlanSummary(create, update, delete)
 	}
 
 	return result

--- a/internal/planner/resource.go
+++ b/internal/planner/resource.go
@@ -306,9 +306,24 @@ func countNoop(rs []Resource) int {
 	return n
 }
 
+// totalUnits counts the resources a plan tracks, for the all-clear message.
+// Filesets are counted per-fileset (one unit each), matching how the changes-only
+// renderer treats a fileset as a single no-op unit.
+func totalUnits(rp *ResourcePlan) int {
+	n := len(rp.Volumes) + len(rp.Networks) + len(rp.Containers) + len(rp.Filesets)
+	for _, services := range rp.Stacks {
+		n += len(services)
+	}
+	return n
+}
+
 // renderResourcePlanChangesOnly renders only changed resources, with a footer
 // count of unchanged (no-op) resources per section.
 func renderResourcePlanChangesOnly(rp *ResourcePlan) string {
+	if c, u, d := rp.CountActions(); c == 0 && u == 0 && d == 0 {
+		return fmt.Sprintf("No changes. %d resources up to date.", totalUnits(rp))
+	}
+
 	var sections []ui.NestedSection
 
 	buildFlatSection := func(title string, resources []Resource) {

--- a/internal/planner/resource.go
+++ b/internal/planner/resource.go
@@ -115,8 +115,8 @@ const filesetChangedFileCap = 10
 
 // PlanRenderOptions controls how a ResourcePlan is rendered.
 type PlanRenderOptions struct {
-	// Full renders all resources including no-ops. When false (changes-only mode,
-	// wired in a later task) only resources with actions are shown.
+	// Full renders the complete plan including unchanged resources; when false,
+	// output is changes-only (only resources with pending actions are shown).
 	Full bool
 }
 
@@ -268,8 +268,9 @@ func appendPlanSummary(result string, rp *ResourcePlan) string {
 	return result
 }
 
-// formatFilesetItem formats a single non-noop fileset item into a DiffLine,
-// using the same logic as the full renderer's fileset loop.
+// formatFilesetItem formats a CHANGED fileset file line. Callers must
+// pre-filter ActionNoop items (the no-op "no file changes" case is handled by
+// the full renderer).
 func formatFilesetItem(res Resource) ui.DiffLine {
 	var msg string
 	if res.Name != "" {

--- a/internal/planner/resource_opts_test.go
+++ b/internal/planner/resource_opts_test.go
@@ -162,6 +162,40 @@ func TestRenderResourcePlanOpts_ChangesOnly_AllStacksUnchanged(t *testing.T) {
 	}
 }
 
+func TestRenderResourcePlanOpts_ChangesOnly_AllClear(t *testing.T) {
+	rp := &ResourcePlan{
+		Volumes: []Resource{
+			NewResource(ResourceVolume, "v1", ActionNoop, "exists"),
+			NewResource(ResourceVolume, "v2", ActionNoop, "exists"),
+		},
+		Networks: []Resource{
+			NewResource(ResourceNetwork, "n1", ActionNoop, "exists"),
+		},
+		Stacks: map[string][]Resource{
+			"ctx/app": {NewResource(ResourceService, "web", ActionNoop, "up-to-date")},
+		},
+		Filesets: map[string][]Resource{
+			"ctx/app/cfg": {NewResource(ResourceFile, "", ActionNoop, "no file changes")},
+		},
+	}
+
+	// changes-only: single concise line
+	got := strings.TrimRight(ui.StripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: false})), "\n")
+	want := "No changes. 5 resources up to date."
+	if got != want {
+		t.Errorf("changes-only all-clear:\ngot:  %q\nwant: %q", got, want)
+	}
+
+	// full mode: unaffected — shows inventory, not the all-clear message
+	full := ui.StripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: true}))
+	if strings.Contains(full, "No changes.") {
+		t.Errorf("full mode should NOT contain 'No changes.', got:\n%s", full)
+	}
+	if !strings.Contains(full, "exists") {
+		t.Errorf("full mode should contain 'exists' (inventory), got:\n%s", full)
+	}
+}
+
 func TestRenderResourcePlanOpts_FullMatchesLegacy(t *testing.T) {
 	rp := &ResourcePlan{
 		Volumes: []Resource{

--- a/internal/planner/resource_opts_test.go
+++ b/internal/planner/resource_opts_test.go
@@ -130,6 +130,25 @@ func TestRenderResourcePlanOpts_ChangesOnly_FilesetCap(t *testing.T) {
 	}
 }
 
+func TestRenderResourcePlanOpts_ChangesOnly_FilesetCapBoundary(t *testing.T) {
+	// Exactly 10 changed files — all must be shown, no "more changed" summary line.
+	items := make([]Resource, 10)
+	for i := range items {
+		items[i] = NewResource(ResourceFile, fmt.Sprintf("f%02d", i+1), ActionUpdate, "")
+	}
+	rp := &ResourcePlan{Filesets: map[string][]Resource{
+		"ctx/a/edge": items,
+	}}
+
+	out := ui.StripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: false}))
+	if !strings.Contains(out, "f10") {
+		t.Errorf("expected 'f10' (10th file) to be shown at the cap boundary, got:\n%s", out)
+	}
+	if strings.Contains(out, "more changed") {
+		t.Errorf("expected NO 'more changed' summary line at exactly the cap (10 files), got:\n%s", out)
+	}
+}
+
 func TestRenderResourcePlanOpts_ChangesOnly_AllStacksUnchanged(t *testing.T) {
 	rp := &ResourcePlan{
 		Volumes: []Resource{NewResource(ResourceVolume, "vNew", ActionCreate, "")},

--- a/internal/planner/resource_opts_test.go
+++ b/internal/planner/resource_opts_test.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -40,6 +41,92 @@ func TestRenderResourcePlanOpts_ChangesOnly_FlatSections(t *testing.T) {
 	}
 	if !strings.Contains(out, "Networks") {
 		t.Errorf("expected output to contain 'Networks' header, got:\n%s", out)
+	}
+}
+
+func TestRenderResourcePlanOpts_ChangesOnly_Stacks(t *testing.T) {
+	rp := &ResourcePlan{Stacks: map[string][]Resource{
+		"ctx/app": {
+			NewResource(ResourceService, "web", ActionCreate, ""),
+			NewResource(ResourceService, "db", ActionNoop, "up-to-date"),
+		},
+		"ctx/idle": {
+			NewResource(ResourceService, "x", ActionNoop, "up-to-date"),
+			NewResource(ResourceService, "y", ActionNoop, "up-to-date"),
+		},
+	}}
+	out := ui.StripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: false}))
+
+	if !strings.Contains(out, "ctx/app") {
+		t.Errorf("expected output to contain 'ctx/app', got:\n%s", out)
+	}
+	if !strings.Contains(out, "web") {
+		t.Errorf("expected output to contain 'web', got:\n%s", out)
+	}
+	if strings.Contains(out, "ctx/idle") {
+		t.Errorf("expected output to NOT contain 'ctx/idle' (all no-op), got:\n%s", out)
+	}
+	if strings.Contains(out, "  x") || strings.Contains(out, "  y") {
+		t.Errorf("expected output to NOT contain noop service lines 'x'/'y', got:\n%s", out)
+	}
+	if strings.Contains(out, " db ") {
+		t.Errorf("expected output to NOT contain noop service 'db', got:\n%s", out)
+	}
+	if !strings.Contains(out, "3 unchanged") {
+		t.Errorf("expected footer '3 unchanged' (db+x+y), got:\n%s", out)
+	}
+	if !strings.Contains(out, "Stacks") {
+		t.Errorf("expected output to contain 'Stacks' header, got:\n%s", out)
+	}
+}
+
+func TestRenderResourcePlanOpts_ChangesOnly_FilesetsCount(t *testing.T) {
+	rp := &ResourcePlan{Filesets: map[string][]Resource{
+		"ctx/a/cfg":  {{Type: ResourceFile, Name: "", Action: ActionNoop, Details: "no file changes", ChangeType: ui.Noop}},
+		"ctx/a/data": {{Type: ResourceFile, Name: "f1", Action: ActionUpdate, Details: "", ChangeType: ui.Change}},
+	}}
+	out := ui.StripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: false}))
+
+	if !strings.Contains(out, "ctx/a/data") {
+		t.Errorf("expected output to contain 'ctx/a/data', got:\n%s", out)
+	}
+	if !strings.Contains(out, "f1") {
+		t.Errorf("expected output to contain 'f1', got:\n%s", out)
+	}
+	if strings.Contains(out, "ctx/a/cfg") {
+		t.Errorf("expected output to NOT contain 'ctx/a/cfg' (fully unchanged), got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 unchanged") {
+		t.Errorf("expected Filesets footer '1 unchanged', got:\n%s", out)
+	}
+}
+
+func TestRenderResourcePlanOpts_ChangesOnly_FilesetCap(t *testing.T) {
+	// 13 changed files, all ActionUpdate
+	items := make([]Resource, 13)
+	for i := range items {
+		items[i] = NewResource(ResourceFile, fmt.Sprintf("f%02d", i+1), ActionUpdate, "")
+	}
+	rp := &ResourcePlan{Filesets: map[string][]Resource{
+		"ctx/a/big": items,
+	}}
+
+	// Changes-only: only 10 shown, remainder summarised
+	out := ui.StripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: false}))
+	if strings.Contains(out, "f11") {
+		t.Errorf("expected 'f11' to be suppressed (beyond cap of 10), got:\n%s", out)
+	}
+	if !strings.Contains(out, "… and 3 more changed (0 created, 3 updated, 0 deleted)") {
+		t.Errorf("expected remainder summary line, got:\n%s", out)
+	}
+
+	// Full: all 13 shown, no "more changed" line
+	outFull := ui.StripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: true}))
+	if !strings.Contains(outFull, "f11") {
+		t.Errorf("expected full render to show 'f11', got:\n%s", outFull)
+	}
+	if strings.Contains(outFull, "more changed") {
+		t.Errorf("expected full render to NOT contain 'more changed', got:\n%s", outFull)
 	}
 }
 

--- a/internal/planner/resource_opts_test.go
+++ b/internal/planner/resource_opts_test.go
@@ -7,10 +7,6 @@ import (
 	"github.com/gcstr/dockform/internal/ui"
 )
 
-func stripANSI(s string) string {
-	return ui.StripANSI(s)
-}
-
 func TestRenderResourcePlanOpts_ChangesOnly_FlatSections(t *testing.T) {
 	rp := &ResourcePlan{
 		Volumes: []Resource{
@@ -22,7 +18,7 @@ func TestRenderResourcePlanOpts_ChangesOnly_FlatSections(t *testing.T) {
 			NewResource(ResourceNetwork, "nKeep", ActionNoop, "exists"),
 		},
 	}
-	out := stripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: false}))
+	out := ui.StripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: false}))
 
 	if !strings.Contains(out, "vNew") {
 		t.Errorf("expected output to contain 'vNew', got:\n%s", out)

--- a/internal/planner/resource_opts_test.go
+++ b/internal/planner/resource_opts_test.go
@@ -1,8 +1,51 @@
 package planner
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/gcstr/dockform/internal/ui"
 )
+
+func stripANSI(s string) string {
+	return ui.StripANSI(s)
+}
+
+func TestRenderResourcePlanOpts_ChangesOnly_FlatSections(t *testing.T) {
+	rp := &ResourcePlan{
+		Volumes: []Resource{
+			NewResource(ResourceVolume, "vNew", ActionCreate, ""),
+			NewResource(ResourceVolume, "vKeep1", ActionNoop, "exists"),
+			NewResource(ResourceVolume, "vKeep2", ActionNoop, "exists"),
+		},
+		Networks: []Resource{
+			NewResource(ResourceNetwork, "nKeep", ActionNoop, "exists"),
+		},
+	}
+	out := stripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: false}))
+
+	if !strings.Contains(out, "vNew") {
+		t.Errorf("expected output to contain 'vNew', got:\n%s", out)
+	}
+	if strings.Contains(out, "vKeep1") {
+		t.Errorf("expected output to NOT contain 'vKeep1' (no-op), got:\n%s", out)
+	}
+	if strings.Contains(out, "vKeep2") {
+		t.Errorf("expected output to NOT contain 'vKeep2' (no-op), got:\n%s", out)
+	}
+	if !strings.Contains(out, "2 unchanged") {
+		t.Errorf("expected Volumes footer '2 unchanged', got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 unchanged") {
+		t.Errorf("expected Networks footer '1 unchanged', got:\n%s", out)
+	}
+	if !strings.Contains(out, "Volumes") {
+		t.Errorf("expected output to contain 'Volumes' header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Networks") {
+		t.Errorf("expected output to contain 'Networks' header, got:\n%s", out)
+	}
+}
 
 func TestRenderResourcePlanOpts_FullMatchesLegacy(t *testing.T) {
 	rp := &ResourcePlan{

--- a/internal/planner/resource_opts_test.go
+++ b/internal/planner/resource_opts_test.go
@@ -1,0 +1,35 @@
+package planner
+
+import (
+	"testing"
+)
+
+func TestRenderResourcePlanOpts_FullMatchesLegacy(t *testing.T) {
+	rp := &ResourcePlan{
+		Volumes: []Resource{
+			NewResource(ResourceVolume, "vNew", ActionCreate, ""),
+			NewResource(ResourceVolume, "vKeep", ActionNoop, "exists"),
+		},
+		Networks: []Resource{
+			NewResource(ResourceNetwork, "nKeep", ActionNoop, "exists"),
+		},
+		Stacks: map[string][]Resource{
+			"ctx/app": {
+				NewResource(ResourceService, "web", ActionCreate, ""),
+				NewResource(ResourceService, "db", ActionNoop, "up-to-date"),
+			},
+		},
+		Filesets: map[string][]Resource{
+			"ctx/app/config": {
+				NewResource(ResourceFile, "", ActionNoop, "no file changes"),
+			},
+		},
+	}
+
+	legacy := RenderResourcePlan(rp)
+	opts := RenderResourcePlanOpts(rp, PlanRenderOptions{Full: true})
+
+	if legacy != opts {
+		t.Errorf("RenderResourcePlanOpts(Full=true) output differs from RenderResourcePlan\nlegacy:\n%s\nopts:\n%s", legacy, opts)
+	}
+}

--- a/internal/planner/resource_opts_test.go
+++ b/internal/planner/resource_opts_test.go
@@ -130,6 +130,38 @@ func TestRenderResourcePlanOpts_ChangesOnly_FilesetCap(t *testing.T) {
 	}
 }
 
+func TestRenderResourcePlanOpts_ChangesOnly_AllStacksUnchanged(t *testing.T) {
+	rp := &ResourcePlan{
+		Volumes: []Resource{NewResource(ResourceVolume, "vNew", ActionCreate, "")},
+		Stacks: map[string][]Resource{
+			"ctx/app": {
+				NewResource(ResourceService, "web", ActionNoop, "up-to-date"),
+				NewResource(ResourceService, "db", ActionNoop, "up-to-date"),
+			},
+		},
+	}
+	out := ui.StripANSI(RenderResourcePlanOpts(rp, PlanRenderOptions{Full: false}))
+
+	if !strings.Contains(out, "Stacks") {
+		t.Errorf("expected output to contain 'Stacks' header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "2 unchanged") {
+		t.Errorf("expected footer '2 unchanged', got:\n%s", out)
+	}
+	if strings.Contains(out, "ctx/app") {
+		t.Errorf("expected output to NOT contain 'ctx/app' subsection (no changed services), got:\n%s", out)
+	}
+	if strings.Contains(out, "web") {
+		t.Errorf("expected output to NOT contain 'web' service line, got:\n%s", out)
+	}
+	if strings.Contains(out, "db") {
+		t.Errorf("expected output to NOT contain 'db' service line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "vNew") {
+		t.Errorf("expected output to contain 'vNew' (volume still rendered), got:\n%s", out)
+	}
+}
+
 func TestRenderResourcePlanOpts_FullMatchesLegacy(t *testing.T) {
 	rp := &ResourcePlan{
 		Volumes: []Resource{

--- a/internal/planner/types.go
+++ b/internal/planner/types.go
@@ -77,6 +77,14 @@ func (pln *Plan) String() string {
 	return RenderResourcePlan(pln.Resources)
 }
 
+// Render renders the plan with the given options (e.g. changes-only vs full).
+func (pln *Plan) Render(opts PlanRenderOptions) string {
+	if pln.Resources == nil {
+		return "[no plan]"
+	}
+	return RenderResourcePlanOpts(pln.Resources, opts)
+}
+
 // GetContextExecutionContext returns the execution context for a specific context.
 func (pln *Plan) GetContextExecutionContext(contextName string) *ContextExecutionContext {
 	if pln.ExecutionContext == nil || pln.ExecutionContext.ByContext == nil {

--- a/internal/ui/footer_test.go
+++ b/internal/ui/footer_test.go
@@ -44,6 +44,42 @@ func TestRenderNestedSections_Footer(t *testing.T) {
 	}
 }
 
+func TestRenderNestedSections_FooterAfterNestedSections(t *testing.T) {
+	sections := []NestedSection{{
+		Title: "Stacks",
+		Sections: []NestedSection{{
+			Title: "ctx/netbird",
+			Items: []DiffLine{{Type: Add, Message: "server will be created"}},
+		}},
+		Footer: []DiffLine{{Type: Info, Message: "44 unchanged"}},
+	}}
+
+	out := StripANSI(RenderNestedSections(sections))
+
+	if !strings.Contains(out, "server will be created") {
+		t.Errorf("expected output to contain nested item message, got:\n%s", out)
+	}
+	if !strings.Contains(out, "44 unchanged") {
+		t.Errorf("expected output to contain footer message, got:\n%s", out)
+	}
+
+	nestedIdx := strings.Index(out, "server will be created")
+	footerIdx := strings.Index(out, "44 unchanged")
+	if footerIdx <= nestedIdx {
+		t.Errorf("expected footer to appear after nested sections, but nested index=%d footer index=%d", nestedIdx, footerIdx)
+	}
+
+	// Footer line must be exactly two leading spaces, no icon
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "44 unchanged") {
+			if line != "  44 unchanged" {
+				t.Errorf("expected footer line to be %q, got %q", "  44 unchanged", line)
+			}
+			break
+		}
+	}
+}
+
 func TestRenderNestedSections_FooterOnly(t *testing.T) {
 	sections := []NestedSection{
 		{

--- a/internal/ui/footer_test.go
+++ b/internal/ui/footer_test.go
@@ -1,0 +1,65 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderNestedSections_Footer(t *testing.T) {
+	sections := []NestedSection{
+		{
+			Title: "Volumes",
+			Items: []DiffLine{
+				{Type: Add, Message: "netbird_data will be created"},
+			},
+			Footer: []DiffLine{
+				{Type: Info, Message: "30 unchanged"},
+			},
+		},
+	}
+
+	out := StripANSI(RenderNestedSections(sections))
+
+	if !strings.Contains(out, "netbird_data will be created") {
+		t.Errorf("expected output to contain item message, got:\n%s", out)
+	}
+	if !strings.Contains(out, "30 unchanged") {
+		t.Errorf("expected output to contain footer message, got:\n%s", out)
+	}
+
+	itemIdx := strings.Index(out, "netbird_data will be created")
+	footerIdx := strings.Index(out, "30 unchanged")
+	if footerIdx <= itemIdx {
+		t.Errorf("expected footer to appear after items, but item index=%d footer index=%d", itemIdx, footerIdx)
+	}
+
+	// Find the line containing "30 unchanged" and assert exact format: two leading spaces, no icon
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "30 unchanged") {
+			if line != "  30 unchanged" {
+				t.Errorf("expected footer line to be %q, got %q", "  30 unchanged", line)
+			}
+			break
+		}
+	}
+}
+
+func TestRenderNestedSections_FooterOnly(t *testing.T) {
+	sections := []NestedSection{
+		{
+			Title: "Networks",
+			Footer: []DiffLine{
+				{Type: Info, Message: "2 unchanged"},
+			},
+		},
+	}
+
+	out := StripANSI(RenderNestedSections(sections))
+
+	if !strings.Contains(out, "Networks") {
+		t.Errorf("expected output to contain section header 'Networks', got:\n%s", out)
+	}
+	if !strings.Contains(out, "2 unchanged") {
+		t.Errorf("expected output to contain footer message '2 unchanged', got:\n%s", out)
+	}
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -58,6 +58,8 @@ var (
 
 	styleNestedSectionTitle = lipgloss.NewStyle().Bold(true).Italic(true)
 
+	styleMuted = lipgloss.NewStyle().Faint(true)
+
 	styleItalicName = lipgloss.NewStyle().Italic(true)
 )
 
@@ -77,6 +79,7 @@ type NestedSection struct {
 	Title    string
 	Items    []DiffLine
 	Sections []NestedSection
+	Footer   []DiffLine
 }
 
 // RenderSectionedList renders sections with simple headers and two-space indented items.
@@ -126,7 +129,7 @@ func RenderNestedSections(sections []NestedSection) string {
 
 	// Check if we have any content to render
 	for _, section := range sections {
-		if len(section.Items) > 0 || len(section.Sections) > 0 {
+		if len(section.Items) > 0 || len(section.Sections) > 0 || len(section.Footer) > 0 {
 			hasAnyContent = true
 			break
 		}
@@ -139,7 +142,7 @@ func RenderNestedSections(sections []NestedSection) string {
 
 	firstSection := true
 	for _, section := range sections {
-		hasContent := len(section.Items) > 0 || len(section.Sections) > 0
+		hasContent := len(section.Items) > 0 || len(section.Sections) > 0 || len(section.Footer) > 0
 		if !hasContent {
 			continue
 		}
@@ -188,6 +191,13 @@ func RenderNestedSections(sections []NestedSection) string {
 				result.WriteString(StripRedundantPrefixes(item.Message, section.Title))
 				result.WriteString("\n")
 			}
+		}
+
+		// Render footer lines: 2-space indent, dim, no icon
+		for _, item := range section.Footer {
+			result.WriteString("  ")
+			result.WriteString(styleMuted.Render(item.Message))
+			result.WriteString("\n")
 		}
 	}
 

--- a/test/e2e/plan_apply_destroy_test.go
+++ b/test/e2e/plan_apply_destroy_test.go
@@ -98,12 +98,16 @@ func TestSimplePlanApplyLifecycle(t *testing.T) {
 		t.Fatalf("expected network labeled io.dockform.identifier=%s", identifier)
 	}
 
-	// Re-PLAN should show up-to-date/noop items
+	// Re-PLAN: the hello service should be up-to-date after apply, i.e. NOT
+	// requiring a create or start. In changes-only output an unchanged service
+	// produces no line at all (it's folded into the stack's "N unchanged"),
+	// so assert the absence of a create/start action for it. (This scenario's
+	// external volume is orphan-flagged on re-plan, so the plan is not fully
+	// no-op — we only assert on the service here.)
 	out2 := runCmd(t, tempDir, env, bin, "plan", "--manifest", tempDir)
-	if !strings.Contains(out2, "[noop] service app/hello up-to-date") && !strings.Contains(out2, "[noop] service app/hello running") {
-		if strings.Contains(out2, "[add] service app/hello will be started") {
-			t.Fatalf("service should not require start after apply, got plan:\n%s", out2)
-		}
+	plain2 := ui.StripANSI(out2)
+	if strings.Contains(plain2, "hello will be created") || strings.Contains(plain2, "hello will be started") {
+		t.Fatalf("service should be up-to-date after apply, got plan:\n%s", out2)
 	}
 }
 
@@ -231,15 +235,26 @@ func TestExamplePlanApplyIdempotentAndPrune(t *testing.T) {
 	if code2 != 0 {
 		t.Fatalf("plan after apply failed: %d\nSTDOUT:\n%s\nSTDERR:\n%s", code2, out2, err2)
 	}
-	// UI may render without explicit [noop] prefix; assert on core phrases instead
-	if !strings.Contains(out2, "demo-volume-1 exists") {
-		t.Fatalf("expected volume exists, got:\n%s", out2)
+	// Default output is changes-only, so a fully up-to-date plan prints the
+	// concise "No changes." message rather than listing unchanged resources.
+	if !strings.Contains(ui.StripANSI(out2), "No changes.") {
+		t.Fatalf("expected idempotent plan to report no changes, got:\n%s", out2)
 	}
-	if !strings.Contains(out2, "demo-network exists") {
-		t.Fatalf("expected network exists, got:\n%s", out2)
+
+	// 3b) --long shows the full inventory of unchanged resources.
+	outLong, errLong, codeLong := runCmdDetailed(t, root, env, bin, "plan", "--long", "--manifest", exampleCfg)
+	if codeLong != 0 {
+		t.Fatalf("plan --long after apply failed: %d\nSTDOUT:\n%s\nSTDERR:\n%s", codeLong, outLong, errLong)
 	}
-	if !strings.Contains(out2, "nginx up-to-date") && !strings.Contains(out2, "nginx running") {
-		t.Fatalf("expected nginx up-to-date or running, got:\n%s", out2)
+	plainLong := ui.StripANSI(outLong)
+	if !strings.Contains(plainLong, "demo-volume-1 exists") {
+		t.Fatalf("expected volume exists in --long output, got:\n%s", outLong)
+	}
+	if !strings.Contains(plainLong, "demo-network exists") {
+		t.Fatalf("expected network exists in --long output, got:\n%s", outLong)
+	}
+	if !strings.Contains(plainLong, "nginx up-to-date") && !strings.Contains(plainLong, "nginx running") {
+		t.Fatalf("expected nginx up-to-date or running in --long output, got:\n%s", outLong)
 	}
 	// Note: "no file changes" check removed - the example scenario doesn't configure filesets
 


### PR DESCRIPTION
This PR updates the default `plan` report to display a tidier output showing only what changed, rather than listing the full state of each daemon.

```
$ dockform plan

│ Identifier:  homeserver
│ Contexts:    hetzner-one · hetzner-three · hetzner-two


Volumes
  35 unchanged

Networks
  1 unchanged

Stacks
  hetzner-one/beszel
    → beszel-agent will be updated
  31 unchanged

Filesets
  9 unchanged

Plan: 0 to create, 1 to change, and 0 to destroy
```

You can still display the full output using the `--long` flag, though:

```
$ dockform plan --long
```