### PR TITLE
perf: batch compose hashing and fileset reads to cut round-trips

### DIFF
--- a/internal/dockercli/compose.go
+++ b/internal/dockercli/compose.go
@@ -136,6 +136,20 @@ func (c *Client) ComposePs(ctx context.Context, workingDir string, files, profil
 	return nil, apperr.New("dockercli.ComposePs", apperr.External, "unexpected compose ps json: %s", util.Truncate(out, 256))
 }
 
+// parseComposeHashLines parses `docker compose config --hash *` output, which is
+// one "<service> <hash>" line per service, into a map of service -> hash.
+func parseComposeHashLines(out string) map[string]string {
+	res := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		res[fields[0]] = fields[len(fields)-1]
+	}
+	return res
+}
+
 // ComposeConfigHash returns the compose config hash for a single service.
 // If identifier is non-empty, a temporary overlay compose file is used to add
 // the label `io.dockform.identifier: <identifier>` to that service before hashing.
@@ -181,25 +195,21 @@ func (c *Client) ComposeConfigHashes(ctx context.Context, workingDir string, fil
 		}
 	}
 	base := c.composeBaseArgs(chosenFiles, profiles, envFiles, projectName)
-	out := make(map[string]string, len(services))
-	for _, svc := range services {
-		args := append(append([]string{}, base...), "config", "--hash", svc)
-		txt, err := c.runInDirOptionalEnv(ctx, workingDir, inlineEnv, args...)
-		if err != nil {
-			return nil, err
-		}
-		trimmed := strings.TrimSpace(txt)
-		firstLine := trimmed
-		if idx := strings.IndexAny(trimmed, "\r\n"); idx >= 0 {
-			firstLine = trimmed[:idx]
-		}
-		fields := strings.Fields(firstLine)
-		if len(fields) == 0 {
-			return nil, apperr.New("dockercli.ComposeConfigHashes", apperr.External, "unexpected compose hash output: %s", util.Truncate(trimmed, 200))
-		}
-		out[svc] = fields[len(fields)-1]
+	args := append(append([]string{}, base...), "config", "--hash", "*")
+	out, err := c.runInDirOptionalEnv(ctx, workingDir, inlineEnv, args...)
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	all := parseComposeHashLines(out)
+	result := make(map[string]string, len(services))
+	for _, svc := range services {
+		h, ok := all[svc]
+		if !ok {
+			return nil, apperr.New("dockercli.ComposeConfigHashes", apperr.External, "compose config --hash '*' missing service %q in output: %s", svc, util.Truncate(out, 200))
+		}
+		result[svc] = h
+	}
+	return result, nil
 }
 
 func (c *Client) composeCacheKey(workingDir string, files, profiles, envFiles []string, inlineEnv []string) string {

--- a/internal/dockercli/compose_test.go
+++ b/internal/dockercli/compose_test.go
@@ -26,6 +26,7 @@ type fakeExec struct {
 	errConfigYAML error
 	errPs         error
 	errHash       error
+	hashCalls     int
 }
 
 func (f *fakeExec) Run(ctx context.Context, args ...string) (string, error) {
@@ -66,6 +67,7 @@ func (f *fakeExec) dispatch(args []string) (string, error) {
 		return f.outPs, f.errPs
 	}
 	if hasSuffix(args, []string{"config", "--hash"}) || contains(args, "--hash") {
+		f.hashCalls++
 		return f.outHash, f.errHash
 	}
 	if hasSuffix(args, []string{"up", "-d"}) {
@@ -188,16 +190,19 @@ func TestComposeConfigHash_ParsesLastField(t *testing.T) {
 }
 
 func TestComposeConfigHashes_ReusesOverlayAndParses(t *testing.T) {
-	// Simulate overlay build (config yaml) once, then two hash calls
-	f := &fakeExec{outConfigYAML: "services:\n  web:\n    image: nginx\n  api:\n    image: busybox\n", outHash: "web deadbeef\n"}
+	// Simulate overlay build (config yaml) once, then single batched hash call
+	f := &fakeExec{outConfigYAML: "services:\n  web:\n    image: nginx\n  api:\n    image: busybox\n", outHash: "web 1111\napi 2222\n"}
 	c := &Client{exec: f, identifier: "demo"}
 	dir := t.TempDir()
 	hashes, err := c.ComposeConfigHashes(context.Background(), dir, []string{"compose.yml"}, nil, nil, "proj", []string{"web", "api"}, "demo", nil)
 	if err != nil {
 		t.Fatalf("multihash: %v", err)
 	}
-	if hashes["web"] != "deadbeef" {
-		t.Fatalf("expected web hash deadbeef, got %#v", hashes)
+	if hashes["web"] != "1111" || hashes["api"] != "2222" {
+		t.Fatalf("unexpected hashes: %v", hashes)
+	}
+	if f.hashCalls != 1 {
+		t.Fatalf("expected exactly 1 hash call (batched), got %d", f.hashCalls)
 	}
 	// Ensure the last command was a hash invocation (not another config yaml render)
 	if !contains(f.lastArgs, "--hash") {
@@ -235,6 +240,24 @@ func TestBuildLabeledProjectTemp_AddsIdentifierLabel(t *testing.T) {
 	// When identifier empty, returns empty path
 	if p2, err := c.buildLabeledProjectTemp(context.Background(), ".", nil, nil, nil, "proj", "", nil); err != nil || p2 != "" {
 		t.Fatalf("expected empty result when identifier empty; got %q err=%v", p2, err)
+	}
+}
+
+func TestParseComposeHashLines(t *testing.T) {
+	out := "web bf6121f2\ncache 781cb76a\nworker 37fd6b88\n"
+	got := parseComposeHashLines(out)
+	want := map[string]string{"web": "bf6121f2", "cache": "781cb76a", "worker": "37fd6b88"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %v", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("hash[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+	// Blank and malformed lines are ignored.
+	if g := parseComposeHashLines("\n  \nweb abc\n"); len(g) != 1 || g["web"] != "abc" {
+		t.Fatalf("expected only web=abc, got %v", g)
 	}
 }
 

--- a/internal/dockercli/dockercli.go
+++ b/internal/dockercli/dockercli.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/gcstr/dockform/internal/apperr"
@@ -312,6 +313,66 @@ func (c *Client) ReadFileFromVolume(ctx context.Context, volumeName, targetPath,
 		return "", err
 	}
 	return strings.TrimRight(out, "\r\n"), nil
+}
+
+// ReadIndexFilesFromVolumes reads relFile from each named volume in a single
+// helper container, returning a map of volume name -> file content (empty string
+// when the file is absent). The file is resolved relative to a synthetic mount
+// per volume, so this collapses N per-volume container boots into one. Volumes
+// must already exist; callers filter to existing volumes.
+func (c *Client) ReadIndexFilesFromVolumes(ctx context.Context, volumeNames []string, relFile string) (map[string]string, error) {
+	result := make(map[string]string, len(volumeNames))
+	if len(volumeNames) == 0 {
+		return result, nil
+	}
+	args := []string{"run", "--rm"}
+	var script strings.Builder
+	for i, vol := range volumeNames {
+		if vol == "" {
+			return nil, apperr.New("dockercli.ReadIndexFilesFromVolumes", apperr.InvalidInput, "empty volume name")
+		}
+		mnt := fmt.Sprintf("/dfidx/%d", i)
+		args = append(args, "-v", fmt.Sprintf("%s:%s:ro", vol, mnt))
+		full := path.Join(mnt, relFile)
+		// Marker line, then file content (or nothing), then a newline so the next
+		// marker always starts on its own line.
+		script.WriteString("echo '===DFIDX:" + fmt.Sprintf("%d", i) + "==='; cat '" + util.ShellEscape(full) + "' 2>/dev/null || true; echo; ")
+	}
+	args = append(args, HelperImage, "sh", "-c", script.String())
+	out, err := c.exec.Run(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	return parseBatchedIndexOutput(out, volumeNames), nil
+}
+
+// parseBatchedIndexOutput splits the delimited helper-container output (blocks
+// separated by "===DFIDX:<i>===" marker lines) back into a volume -> content map.
+func parseBatchedIndexOutput(out string, volumeNames []string) map[string]string {
+	res := make(map[string]string, len(volumeNames))
+	cur := -1
+	var buf []string
+	flush := func() {
+		if cur >= 0 && cur < len(volumeNames) {
+			res[volumeNames[cur]] = strings.TrimRight(strings.Join(buf, "\n"), "\r\n")
+		}
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "===DFIDX:") && strings.HasSuffix(line, "===") {
+			flush()
+			idxStr := strings.TrimSuffix(strings.TrimPrefix(line, "===DFIDX:"), "===")
+			if n, err := strconv.Atoi(idxStr); err == nil {
+				cur = n
+			} else {
+				cur = -1
+			}
+			buf = nil
+			continue
+		}
+		buf = append(buf, line)
+	}
+	flush()
+	return res
 }
 
 // WriteFileToVolume writes content to a file inside a mounted volume target path, creating parent directories.

--- a/internal/dockercli/dockercli.go
+++ b/internal/dockercli/dockercli.go
@@ -348,6 +348,9 @@ func (c *Client) ReadIndexFilesFromVolumes(ctx context.Context, volumeNames []st
 
 // parseBatchedIndexOutput splits the delimited helper-container output (blocks
 // separated by "===DFIDX:<i>===" marker lines) back into a volume -> content map.
+// This relies on the index being compact single-line JSON (filesets.Index.ToJSON),
+// so a content line can never look like a "===DFIDX:<i>===" marker; if ToJSON ever
+// emits multi-line/indented output, the delimiter scheme would need revisiting.
 func parseBatchedIndexOutput(out string, volumeNames []string) map[string]string {
 	res := make(map[string]string, len(volumeNames))
 	cur := -1

--- a/internal/dockercli/dockercli_test.go
+++ b/internal/dockercli/dockercli_test.go
@@ -210,3 +210,19 @@ func mustWriteFile(t *testing.T, path string, b []byte) {
 		t.Fatalf("write file: %v", err)
 	}
 }
+
+func TestParseBatchedIndexOutput(t *testing.T) {
+	vols := []string{"volA", "volB", "volC"}
+	// volB has no file (empty block); volA and volC have JSON.
+	out := "===DFIDX:0===\n{\"version\":\"v1\"}\n\n===DFIDX:1===\n\n===DFIDX:2===\n{\"a\":1}\n\n"
+	got := parseBatchedIndexOutput(out, vols)
+	if got["volA"] != `{"version":"v1"}` {
+		t.Fatalf("volA = %q", got["volA"])
+	}
+	if got["volB"] != "" {
+		t.Fatalf("volB should be empty, got %q", got["volB"])
+	}
+	if got["volC"] != `{"a":1}` {
+		t.Fatalf("volC = %q", got["volC"])
+	}
+}

--- a/internal/planner/build_plan_filesets.go
+++ b/internal/planner/build_plan_filesets.go
@@ -51,7 +51,39 @@ func (p *Planner) buildFilesetResourcesForContext(ctx context.Context, filesetSp
 		localIndexes[res.name] = res.index
 	}
 
-	// Phase 2: read remote indexes sequentially to avoid SSH connection floods.
+	// Phase 2: batch-read remote indexes for all existing fileset volumes in a
+	// single helper container (one boot per host instead of one per fileset).
+	volSet := map[string]struct{}{}
+	for _, name := range filesetNames {
+		if _, ok := localIndexes[name]; !ok {
+			continue
+		}
+		a := filesetSpecs[name]
+		if _, exists := existingVolumes[a.TargetVolume]; exists {
+			volSet[a.TargetVolume] = struct{}{}
+		}
+	}
+	indexByVolume := map[string]string{}
+	if len(volSet) > 0 {
+		vols := sortedKeys(volSet)
+		m, err := client.ReadIndexFilesFromVolumes(ctx, vols, filesets.IndexFileName)
+		if err != nil {
+			// Degrade gracefully: mark every fileset whose volume we could not read.
+			for _, name := range filesetNames {
+				if _, ok := localIndexes[name]; !ok {
+					continue
+				}
+				a := filesetSpecs[name]
+				if _, exists := existingVolumes[a.TargetVolume]; exists {
+					plan.Filesets[name] = []Resource{NewResource(ResourceFile, "", ActionUpdate, "unable to read remote index")}
+					errs = append(errs, apperr.Wrap("planner.buildFilesetResourcesForContext", apperr.External, err, "read remote indexes (batched)"))
+				}
+			}
+			return apperr.Aggregate("planner.buildFilesetResourcesForContext", apperr.External, "one or more fileset analyses failed", errs...)
+		}
+		indexByVolume = m
+	}
+
 	for _, name := range filesetNames {
 		local, ok := localIndexes[name]
 		if !ok {
@@ -61,13 +93,7 @@ func (p *Planner) buildFilesetResourcesForContext(ctx context.Context, filesetSp
 
 		raw := ""
 		if _, volumeExists := existingVolumes[a.TargetVolume]; volumeExists {
-			var err error
-			raw, err = client.ReadFileFromVolume(ctx, a.TargetVolume, a.TargetPath, filesets.IndexFileName)
-			if err != nil {
-				plan.Filesets[name] = []Resource{NewResource(ResourceFile, "", ActionUpdate, "unable to read remote index")}
-				errs = append(errs, apperr.Wrap("planner.buildFilesetResourcesForContext", apperr.External, err, "read remote index for %s", name))
-				continue
-			}
+			raw = indexByVolume[a.TargetVolume]
 		}
 		remote, err := filesets.ParseIndexJSON(raw)
 		if err != nil {

--- a/internal/planner/build_plan_filesets.go
+++ b/internal/planner/build_plan_filesets.go
@@ -69,6 +69,10 @@ func (p *Planner) buildFilesetResourcesForContext(ctx context.Context, filesetSp
 		m, err := client.ReadIndexFilesFromVolumes(ctx, vols, filesets.IndexFileName)
 		if err != nil {
 			// Degrade gracefully: mark every fileset whose volume we could not read.
+			// This is an intentional trade-off of batching: a single failed batched read
+			// marks the WHOLE context's filesets as "unable to read remote index" (wider
+			// blast radius than the old per-fileset read), in exchange for one container
+			// boot per host instead of one per fileset.
 			for _, name := range filesetNames {
 				if _, ok := localIndexes[name]; !ok {
 					continue
@@ -76,9 +80,9 @@ func (p *Planner) buildFilesetResourcesForContext(ctx context.Context, filesetSp
 				a := filesetSpecs[name]
 				if _, exists := existingVolumes[a.TargetVolume]; exists {
 					plan.Filesets[name] = []Resource{NewResource(ResourceFile, "", ActionUpdate, "unable to read remote index")}
-					errs = append(errs, apperr.Wrap("planner.buildFilesetResourcesForContext", apperr.External, err, "read remote indexes (batched)"))
 				}
 			}
+			errs = append(errs, apperr.Wrap("planner.buildFilesetResourcesForContext", apperr.External, err, "read remote indexes (batched)"))
 			return apperr.Aggregate("planner.buildFilesetResourcesForContext", apperr.External, "one or more fileset analyses failed", errs...)
 		}
 		indexByVolume = m

--- a/internal/planner/build_plan_filesets_test.go
+++ b/internal/planner/build_plan_filesets_test.go
@@ -1,0 +1,50 @@
+package planner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gcstr/dockform/internal/filesets"
+	"github.com/gcstr/dockform/internal/manifest"
+)
+
+func TestBuildFilesetResources_BatchesRemoteIndexReads(t *testing.T) {
+	m := newMockDocker()
+	m.volumes = []string{"vol1", "vol2"}
+
+	// Build a local index for an empty source dir so its tree hash is deterministic,
+	// then store a matching JSON for vol1 in m.volumeFiles.
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	specs := map[string]manifest.FilesetSpec{
+		"ctx/s/vol1": {SourceAbs: dir1, TargetPath: "/data", TargetVolume: "vol1"},
+		"ctx/s/vol2": {SourceAbs: dir2, TargetPath: "/data", TargetVolume: "vol2"},
+	}
+
+	local1, err := filesets.BuildLocalIndex(dir1, "/data", nil)
+	if err != nil {
+		t.Fatalf("local index: %v", err)
+	}
+	idxJSON, err := local1.ToJSON() // same serializer the apply path uses (filesets.Index.ToJSON)
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+	m.volumeFiles["vol1"] = idxJSON
+
+	existing := map[string]struct{}{"vol1": {}, "vol2": {}}
+	plan := &ResourcePlan{Filesets: map[string][]Resource{}}
+	execCtx := &ContextExecutionContext{Filesets: map[string]*FilesetExecutionData{}}
+
+	p := &Planner{}
+	if err := p.buildFilesetResourcesForContext(context.Background(), specs, existing, m, plan, execCtx); err != nil {
+		t.Fatalf("buildFilesetResourcesForContext: %v", err)
+	}
+
+	if m.readIndexBatchCalls != 1 {
+		t.Fatalf("expected exactly 1 batched index read, got %d", m.readIndexBatchCalls)
+	}
+	// vol1 matched -> no-op; vol2 empty remote -> changes (or no-op if dir2 empty too).
+	if len(plan.Filesets["ctx/s/vol1"]) == 0 {
+		t.Fatalf("expected a resource entry for vol1")
+	}
+}

--- a/internal/planner/interfaces.go
+++ b/internal/planner/interfaces.go
@@ -17,6 +17,7 @@ type DockerClient interface {
 
 	// Volume file operations
 	ReadFileFromVolume(ctx context.Context, volumeName, targetPath, relFile string) (string, error)
+	ReadIndexFilesFromVolumes(ctx context.Context, volumeNames []string, relFile string) (map[string]string, error)
 	WriteFileToVolume(ctx context.Context, volumeName, targetPath, relFile, content string) error
 	ExtractTarToVolume(ctx context.Context, volumeName, targetPath string, tarReader io.Reader) error
 	RemovePathsFromVolume(ctx context.Context, volumeName, targetPath string, relPaths []string) error

--- a/internal/planner/mock_docker_test.go
+++ b/internal/planner/mock_docker_test.go
@@ -32,6 +32,7 @@ type mockDockerClient struct {
 	extractedTars       []string            // volume names that had tars extracted
 	removedPaths        map[string][]string // volumeName -> removed paths
 	runVolumeScriptRuns int
+	readIndexBatchCalls int
 
 	// Control behavior
 	listVolumesError             error
@@ -110,6 +111,15 @@ func (m *mockDockerClient) ReadFileFromVolume(ctx context.Context, volumeName, t
 		return "", nil
 	}
 	return content, nil
+}
+
+func (m *mockDockerClient) ReadIndexFilesFromVolumes(ctx context.Context, volumeNames []string, relFile string) (map[string]string, error) {
+	m.readIndexBatchCalls++
+	res := make(map[string]string, len(volumeNames))
+	for _, v := range volumeNames {
+		res[v] = m.volumeFiles[v] // "" when absent, mirroring ReadFileFromVolume
+	}
+	return res, nil
 }
 
 func (m *mockDockerClient) RunVolumeScript(ctx context.Context, volumeName, targetPath, script string, env []string) (dockercli.VolumeScriptResult, error) {

--- a/internal/planner/planner_filesets_test.go
+++ b/internal/planner/planner_filesets_test.go
@@ -29,6 +29,8 @@ case "$cmd" in
   run)
     # WriteFileToVolume: detect cat > and log
     for a in "$@"; do echo "$a" | grep -q "cat > "; if [ $? -eq 0 ]; then echo "write_index" >> "$log"; exit 0; fi; done
+    # ReadIndexFilesFromVolumes (batched): emit marker-delimited remote index
+    for a in "$@"; do echo "$a" | grep -q "===DFIDX:" && { printf '===DFIDX:0===\n%s\n' "$REMOTE_JSON"; exit 0; }; done
     # ReadFileFromVolume: cat index (non-redirect)
     for a in "$@"; do echo "$a" | grep -q "cat "; if [ $? -eq 0 ]; then printf '%s' "$REMOTE_JSON"; exit 0; fi; done
     # Extract tar


### PR DESCRIPTION
Plan/apply over remote SSH contexts made one Docker call per service for config hashing and one helper-container boot per fileset volume to read the remote index. This PR batches both. Only one `docker compose config --hash '*'` per stack and one helper container per host.