### PR TITLE
feat: transparent SSH multiplexing

### DIFF
--- a/cmd/dockform/main.go
+++ b/cmd/dockform/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/gcstr/dockform/internal/cli"
+	"github.com/gcstr/dockform/internal/sshmux"
 )
 
 var (
@@ -29,5 +31,12 @@ func run() int {
 }
 
 func main() {
+	if sshmux.ShouldRunAsShim(os.Args[0]) {
+		if err := sshmux.Run(os.Args[0], os.Args[1:]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(255)
+		}
+		return
+	}
 	os.Exit(run())
 }

--- a/internal/cli/common/context.go
+++ b/internal/cli/common/context.go
@@ -67,6 +67,9 @@ func SetupCLIContext(cmd *cobra.Command) (*CLIContext, error) {
 		return nil, err
 	}
 
+	// Install run-scoped SSH multiplexing (best-effort) before any docker work.
+	ActivateSSHMux(cmd, cfg)
+
 	// Validate in spinner
 	err = SpinnerOperation(pr, "Validating...", func() error {
 		return ValidateWithFactory(cmd.Context(), cfg, factory)

--- a/internal/cli/common/sshmux.go
+++ b/internal/cli/common/sshmux.go
@@ -59,15 +59,20 @@ func ActivateSSHMux(cmd *cobra.Command, cfg *manifest.Config) {
 	if err != nil {
 		return
 	}
-	cmd.SetContext(context.WithValue(cmd.Context(), sshMuxKey{}, mgr))
+	root := cmd.Root()
+	root.SetContext(context.WithValue(root.Context(), sshMuxKey{}, mgr))
 }
 
 // TeardownSSHMux tears down any multiplexing installed for this command.
 func TeardownSSHMux(cmd *cobra.Command) {
-	if cmd == nil || cmd.Context() == nil {
+	if cmd == nil {
 		return
 	}
-	if mgr, ok := cmd.Context().Value(sshMuxKey{}).(*sshmux.Manager); ok {
+	root := cmd.Root()
+	if root.Context() == nil {
+		return
+	}
+	if mgr, ok := root.Context().Value(sshMuxKey{}).(*sshmux.Manager); ok {
 		mgr.Teardown()
 	}
 }

--- a/internal/cli/common/sshmux.go
+++ b/internal/cli/common/sshmux.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/gcstr/dockform/internal/manifest"
+	"github.com/gcstr/dockform/internal/sshmux"
+	"github.com/spf13/cobra"
+)
+
+type sshMuxKey struct{}
+
+// MultiplexEnabled resolves whether SSH multiplexing is on. Precedence: an
+// explicitly-set --ssh-multiplex flag wins; otherwise DOCKFORM_SSH_MULTIPLEX
+// (when parseable) decides; otherwise it defaults to true.
+func MultiplexEnabled(cmd *cobra.Command) bool {
+	if f := cmd.Flags().Lookup("ssh-multiplex"); f != nil && f.Changed {
+		v, _ := cmd.Flags().GetBool("ssh-multiplex")
+		return v
+	}
+	if raw, ok := os.LookupEnv("DOCKFORM_SSH_MULTIPLEX"); ok {
+		if v, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
+			return v
+		}
+	}
+	return true
+}
+
+// HasRemoteContext reports whether any context could use SSH (an ssh:// host
+// override, or a named non-default context).
+func HasRemoteContext(cfg *manifest.Config) bool {
+	for name, cc := range cfg.Contexts {
+		if strings.HasPrefix(cc.Host, "ssh://") {
+			return true
+		}
+		if name != "" && name != "default" {
+			return true
+		}
+	}
+	return false
+}
+
+// ActivateSSHMux installs run-scoped SSH multiplexing when enabled and at least
+// one context is remote. Best-effort: on any failure it silently falls back to
+// the current per-call behavior. The Manager is stashed in cmd's context for
+// TeardownSSHMux to retrieve.
+func ActivateSSHMux(cmd *cobra.Command, cfg *manifest.Config) {
+	if !MultiplexEnabled(cmd) || !HasRemoteContext(cfg) {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	mgr, err := sshmux.Setup(exe)
+	if err != nil {
+		return
+	}
+	cmd.SetContext(context.WithValue(cmd.Context(), sshMuxKey{}, mgr))
+}
+
+// TeardownSSHMux tears down any multiplexing installed for this command.
+func TeardownSSHMux(cmd *cobra.Command) {
+	if cmd == nil || cmd.Context() == nil {
+		return
+	}
+	if mgr, ok := cmd.Context().Value(sshMuxKey{}).(*sshmux.Manager); ok {
+		mgr.Teardown()
+	}
+}

--- a/internal/cli/common/sshmux_test.go
+++ b/internal/cli/common/sshmux_test.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/gcstr/dockform/internal/manifest"
+	"github.com/spf13/cobra"
+)
+
+func TestHasRemoteContext(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  manifest.Config
+		want bool
+	}{
+		{"only default", manifest.Config{Contexts: map[string]manifest.ContextConfig{"default": {}}}, false},
+		{"ssh host override", manifest.Config{Contexts: map[string]manifest.ContextConfig{"default": {Host: "ssh://u@h"}}}, true},
+		{"named non-default", manifest.Config{Contexts: map[string]manifest.ContextConfig{"hetzner": {}}}, true},
+		{"empty", manifest.Config{Contexts: map[string]manifest.ContextConfig{}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasRemoteContext(&tc.cfg); got != tc.want {
+				t.Fatalf("HasRemoteContext = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func newMuxCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("ssh-multiplex", true, "")
+	return cmd
+}
+
+func TestMultiplexEnabled_Precedence(t *testing.T) {
+	// Default: no flag change, no env → true.
+	if !MultiplexEnabled(newMuxCmd()) {
+		t.Fatal("default should be true")
+	}
+
+	// Env disables when no flag change.
+	t.Setenv("DOCKFORM_SSH_MULTIPLEX", "false")
+	if MultiplexEnabled(newMuxCmd()) {
+		t.Fatal("env false should disable when flag unchanged")
+	}
+
+	// Explicit flag overrides env.
+	cmd := newMuxCmd()
+	_ = cmd.Flags().Set("ssh-multiplex", "true")
+	if !MultiplexEnabled(cmd) {
+		t.Fatal("explicit flag true should override env false")
+	}
+
+	// Unparseable env falls back to default true.
+	t.Setenv("DOCKFORM_SSH_MULTIPLEX", "garbage")
+	if !MultiplexEnabled(newMuxCmd()) {
+		t.Fatal("unparseable env should fall back to default true")
+	}
+}

--- a/internal/cli/common/sshmux_test.go
+++ b/internal/cli/common/sshmux_test.go
@@ -1,9 +1,12 @@
 package common
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	"github.com/gcstr/dockform/internal/manifest"
+	"github.com/gcstr/dockform/internal/sshmux"
 	"github.com/spf13/cobra"
 )
 
@@ -56,5 +59,46 @@ func TestMultiplexEnabled_Precedence(t *testing.T) {
 	t.Setenv("DOCKFORM_SSH_MULTIPLEX", "garbage")
 	if !MultiplexEnabled(newMuxCmd()) {
 		t.Fatal("unparseable env should fall back to default true")
+	}
+}
+
+func TestActivateTeardownRoundTrip_RemovesRunDir(t *testing.T) {
+	// Mirror the real wiring: ActivateSSHMux runs inside a leaf subcommand's
+	// RunE, TeardownSSHMux runs on the root command (as root.Execute does).
+	root := &cobra.Command{Use: "dockform"}
+	root.PersistentFlags().Bool("ssh-multiplex", true, "")
+
+	var capturedDir string
+	leaf := &cobra.Command{
+		Use: "plan",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg := &manifest.Config{Contexts: map[string]manifest.ContextConfig{"remote": {}}}
+			ActivateSSHMux(cmd, cfg)
+			capturedDir = os.Getenv(sshmux.ControlEnvVar)
+			return nil
+		},
+	}
+	root.AddCommand(leaf)
+
+	oldPath := os.Getenv("PATH")
+	root.SetArgs([]string{"plan"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if capturedDir == "" {
+		t.Fatal("ActivateSSHMux did not install multiplexing for a remote context")
+	}
+	if _, err := os.Stat(capturedDir); err != nil {
+		t.Fatalf("expected run dir to exist during run: %v", err)
+	}
+
+	// Teardown on the ROOT command, exactly as root.Execute does.
+	TeardownSSHMux(root)
+
+	if _, err := os.Stat(capturedDir); !os.IsNotExist(err) {
+		t.Fatalf("run dir not removed after teardown (manager not found on root context): %v", err)
+	}
+	if os.Getenv("PATH") != oldPath {
+		t.Errorf("PATH not restored after teardown")
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,11 +11,12 @@ import (
 	"github.com/gcstr/dockform/internal/apperr"
 	"github.com/gcstr/dockform/internal/cli/applycmd"
 	"github.com/gcstr/dockform/internal/cli/buildinfo"
+	"github.com/gcstr/dockform/internal/cli/common"
 	"github.com/gcstr/dockform/internal/cli/composecmd"
 	"github.com/gcstr/dockform/internal/cli/dashboardcmd"
-	"github.com/gcstr/dockform/internal/cli/imagescmd"
 	"github.com/gcstr/dockform/internal/cli/destroycmd"
 	"github.com/gcstr/dockform/internal/cli/doctorcmd"
+	"github.com/gcstr/dockform/internal/cli/imagescmd"
 	"github.com/gcstr/dockform/internal/cli/initcmd"
 	"github.com/gcstr/dockform/internal/cli/manifestcmd"
 	"github.com/gcstr/dockform/internal/cli/plancmd"
@@ -39,6 +40,7 @@ func Execute(ctx context.Context) int {
 	cmd := newRootCmd()
 	err := cmd.ExecuteContext(ctx)
 	closeLogCloser(cmd)
+	common.TeardownSSHMux(cmd)
 	if err != nil {
 		// Check if the error is a context cancellation (user interrupted)
 		// If so, don't print the error and exit with code 130 (128 + SIGINT)
@@ -107,6 +109,7 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().String("log-format", "auto", "Log format: auto, pretty, json")
 	cmd.PersistentFlags().String("log-file", "", "Write logs to file using the format specified by --log-format (in addition to stderr)")
 	cmd.PersistentFlags().Bool("no-color", false, "Disable color in pretty logs")
+	cmd.PersistentFlags().Bool("ssh-multiplex", true, "Reuse one SSH connection per host for a run (ControlMaster); disable with --ssh-multiplex=false or DOCKFORM_SSH_MULTIPLEX=false")
 
 	cmd.AddCommand(initcmd.New())
 	cmd.AddCommand(plancmd.New())

--- a/internal/sshmux/manager.go
+++ b/internal/sshmux/manager.go
@@ -1,0 +1,59 @@
+package sshmux
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Manager holds run-scoped multiplexing state so it can be torn down.
+type Manager struct {
+	dir      string
+	oldPath  string
+	prevCtrl string
+	hadCtrl  bool
+	active   bool
+}
+
+// Setup installs the ssh shim for the lifetime of a run. It creates a short
+// run-scoped dir under /tmp (NOT $TMPDIR — macOS's is too long for the ~104-char
+// ControlPath limit), symlinks `ssh` to the running dockform binary inside it,
+// prepends that dir to PATH, and exports the control dir for the shim.
+func Setup(selfExe string) (*Manager, error) {
+	dir, err := os.MkdirTemp("/tmp", "dfssh-")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Symlink(selfExe, filepath.Join(dir, "ssh")); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
+	oldPath := os.Getenv("PATH")
+	prevCtrl, hadCtrl := os.LookupEnv(ControlEnvVar)
+	_ = os.Setenv("PATH", dir+string(os.PathListSeparator)+oldPath)
+	_ = os.Setenv(ControlEnvVar, dir)
+	return &Manager{dir: dir, oldPath: oldPath, prevCtrl: prevCtrl, hadCtrl: hadCtrl, active: true}, nil
+}
+
+// Dir returns the run-scoped control directory.
+func (m *Manager) Dir() string {
+	if m == nil {
+		return ""
+	}
+	return m.dir
+}
+
+// Teardown restores PATH and the control env var and removes the run dir. Any
+// lingering ssh master self-exits via ControlPersist. Idempotent and nil-safe.
+func (m *Manager) Teardown() {
+	if m == nil || !m.active {
+		return
+	}
+	m.active = false
+	_ = os.Setenv("PATH", m.oldPath)
+	if m.hadCtrl {
+		_ = os.Setenv(ControlEnvVar, m.prevCtrl)
+	} else {
+		_ = os.Unsetenv(ControlEnvVar)
+	}
+	_ = os.RemoveAll(m.dir)
+}

--- a/internal/sshmux/manager_test.go
+++ b/internal/sshmux/manager_test.go
@@ -1,0 +1,59 @@
+package sshmux
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetupAndTeardown(t *testing.T) {
+	selfExe := filepath.Join(t.TempDir(), "dockform")
+	if err := os.WriteFile(selfExe, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write selfExe: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	if _, had := os.LookupEnv(ControlEnvVar); had {
+		t.Skip("ControlEnvVar already set in environment")
+	}
+
+	mgr, err := Setup(selfExe)
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	if !strings.HasPrefix(mgr.Dir(), "/tmp/dfssh-") {
+		t.Fatalf("dir %q not under /tmp/dfssh-", mgr.Dir())
+	}
+	if len(mgr.Dir()) > 40 {
+		t.Fatalf("control dir too long for ControlPath budget: %q (%d)", mgr.Dir(), len(mgr.Dir()))
+	}
+	link := filepath.Join(mgr.Dir(), "ssh")
+	if target, err := os.Readlink(link); err != nil || target != selfExe {
+		t.Fatalf("symlink target = %q (err %v), want %q", target, err, selfExe)
+	}
+	if !strings.HasPrefix(os.Getenv("PATH"), mgr.Dir()+string(os.PathListSeparator)) {
+		t.Fatalf("PATH not prepended with shim dir: %q", os.Getenv("PATH"))
+	}
+	if os.Getenv(ControlEnvVar) != mgr.Dir() {
+		t.Fatalf("%s = %q, want %q", ControlEnvVar, os.Getenv(ControlEnvVar), mgr.Dir())
+	}
+
+	mgr.Teardown()
+
+	if os.Getenv("PATH") != oldPath {
+		t.Fatalf("PATH not restored: %q != %q", os.Getenv("PATH"), oldPath)
+	}
+	if _, ok := os.LookupEnv(ControlEnvVar); ok {
+		t.Fatalf("%s not unset after teardown", ControlEnvVar)
+	}
+	if _, err := os.Stat(mgr.Dir()); !os.IsNotExist(err) {
+		t.Fatalf("run dir not removed: %v", err)
+	}
+
+	// Idempotent / nil-safe.
+	mgr.Teardown()
+	var nilMgr *Manager
+	nilMgr.Teardown()
+}

--- a/internal/sshmux/shim.go
+++ b/internal/sshmux/shim.go
@@ -1,0 +1,93 @@
+// Package sshmux provides run-scoped SSH connection multiplexing. The dockform
+// binary, when invoked through a `ssh` symlink on PATH, acts as a transparent
+// shim that execs the real ssh with ControlMaster options injected, so docker's
+// ssh connection helper reuses one connection per host for a run's lifetime.
+package sshmux
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// ControlEnvVar carries the run-scoped ControlPath base dir to the shim process.
+// Its presence also signals that multiplexing is active for this run.
+const ControlEnvVar = "DOCKFORM_SSH_CONTROL_DIR"
+
+// InjectedOptions returns the ssh -o flags that enable run-scoped multiplexing.
+// ControlPath uses ssh's %C token (a hash of host/port/user) to stay short and
+// unique per destination, well under the ~104-char unix socket limit.
+func InjectedOptions(controlDir string) []string {
+	return []string{
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=" + filepath.Join(controlDir, "%C"),
+		"-o", "ControlPersist=60",
+		"-o", "ServerAliveInterval=15",
+		"-o", "ServerAliveCountMax=3",
+	}
+}
+
+// FindRealSSH returns the first `ssh` on pathEnv that is not inside shimDir, so
+// the shim never recurses into itself.
+func FindRealSSH(shimDir, pathEnv string) (string, error) {
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" || sameDir(dir, shimDir) {
+			continue
+		}
+		cand := filepath.Join(dir, "ssh")
+		if isExecutable(cand) {
+			return cand, nil
+		}
+	}
+	return "", fmt.Errorf("sshmux: real ssh not found on PATH (excluding %s)", shimDir)
+}
+
+// ShimArgs builds argv for exec'ing the real ssh: realSSH, injected options,
+// then the original incoming args (the destination and docker's own flags).
+func ShimArgs(realSSH, controlDir string, incoming []string) []string {
+	argv := make([]string, 0, 1+10+len(incoming))
+	argv = append(argv, realSSH)
+	argv = append(argv, InjectedOptions(controlDir)...)
+	argv = append(argv, incoming...)
+	return argv
+}
+
+// ShouldRunAsShim reports whether the binary was invoked through its ssh symlink.
+func ShouldRunAsShim(arg0 string) bool {
+	return filepath.Base(arg0) == "ssh"
+}
+
+// Run is the shim entrypoint. It execs the real ssh, injecting multiplexing
+// options when a control dir is configured. It does not return on success.
+func Run(arg0 string, incoming []string) error {
+	shimDir := filepath.Dir(arg0)
+	realSSH, err := FindRealSSH(shimDir, os.Getenv("PATH"))
+	if err != nil {
+		return err
+	}
+	var argv []string
+	if controlDir := os.Getenv(ControlEnvVar); controlDir != "" {
+		argv = ShimArgs(realSSH, controlDir, incoming)
+	} else {
+		argv = append([]string{realSSH}, incoming...)
+	}
+	return syscall.Exec(realSSH, argv, os.Environ())
+}
+
+func sameDir(a, b string) bool {
+	ra, err1 := filepath.Abs(a)
+	rb, err2 := filepath.Abs(b)
+	if err1 != nil || err2 != nil {
+		return a == b
+	}
+	return ra == rb
+}
+
+func isExecutable(p string) bool {
+	fi, err := os.Stat(p)
+	if err != nil || fi.IsDir() {
+		return false
+	}
+	return fi.Mode()&0o111 != 0
+}

--- a/internal/sshmux/shim.go
+++ b/internal/sshmux/shim.go
@@ -15,6 +15,9 @@ import (
 // Its presence also signals that multiplexing is active for this run.
 const ControlEnvVar = "DOCKFORM_SSH_CONTROL_DIR"
 
+// injectedOptionsCount is the number of elements returned by InjectedOptions.
+const injectedOptionsCount = 10
+
 // InjectedOptions returns the ssh -o flags that enable run-scoped multiplexing.
 // ControlPath uses ssh's %C token (a hash of host/port/user) to stay short and
 // unique per destination, well under the ~104-char unix socket limit.
@@ -46,7 +49,7 @@ func FindRealSSH(shimDir, pathEnv string) (string, error) {
 // ShimArgs builds argv for exec'ing the real ssh: realSSH, injected options,
 // then the original incoming args (the destination and docker's own flags).
 func ShimArgs(realSSH, controlDir string, incoming []string) []string {
-	argv := make([]string, 0, 1+10+len(incoming))
+	argv := make([]string, 0, 1+injectedOptionsCount+len(incoming))
 	argv = append(argv, realSSH)
 	argv = append(argv, InjectedOptions(controlDir)...)
 	argv = append(argv, incoming...)

--- a/internal/sshmux/shim_test.go
+++ b/internal/sshmux/shim_test.go
@@ -1,0 +1,78 @@
+package sshmux
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInjectedOptions(t *testing.T) {
+	opts := InjectedOptions("/tmp/dfssh-abc")
+	joined := strings.Join(opts, " ")
+	for _, want := range []string{
+		"ControlMaster=auto",
+		"ControlPath=/tmp/dfssh-abc/%C",
+		"ControlPersist=60",
+		"ServerAliveInterval=15",
+		"ServerAliveCountMax=3",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("missing %q in %q", want, joined)
+		}
+	}
+}
+
+func TestShimArgs_OrdersOptionsBeforeIncoming(t *testing.T) {
+	got := ShimArgs("/usr/bin/ssh", "/tmp/dfssh-abc", []string{"-l", "user", "host", "--", "docker"})
+	if got[0] != "/usr/bin/ssh" {
+		t.Fatalf("argv[0] = %q, want real ssh", got[0])
+	}
+	iCtrl := indexOf(got, "ControlMaster=auto")
+	iHost := indexOf(got, "host")
+	if iCtrl < 0 || iHost < 0 || iCtrl > iHost {
+		t.Fatalf("expected injected options before incoming args: %v", got)
+	}
+}
+
+func TestFindRealSSH_SkipsShimDir(t *testing.T) {
+	shimDir := t.TempDir()
+	realDir := t.TempDir()
+	mustWriteExec(t, filepath.Join(shimDir, "ssh"))
+	realSSH := filepath.Join(realDir, "ssh")
+	mustWriteExec(t, realSSH)
+
+	pathEnv := shimDir + string(os.PathListSeparator) + realDir
+	got, err := FindRealSSH(shimDir, pathEnv)
+	if err != nil {
+		t.Fatalf("FindRealSSH: %v", err)
+	}
+	if got != realSSH {
+		t.Fatalf("FindRealSSH = %q, want %q (must skip shim dir)", got, realSSH)
+	}
+}
+
+func TestShouldRunAsShim(t *testing.T) {
+	if !ShouldRunAsShim("/tmp/dfssh-x/ssh") {
+		t.Fatal("expected true when invoked as ssh")
+	}
+	if ShouldRunAsShim("/usr/local/bin/dockform") {
+		t.Fatal("expected false for normal invocation")
+	}
+}
+
+func indexOf(s []string, sub string) int {
+	for i, v := range s {
+		if strings.Contains(v, sub) {
+			return i
+		}
+	}
+	return -1
+}
+
+func mustWriteExec(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write exec: %v", err)
+	}
+}


### PR DESCRIPTION
Every `docker` call against an `ssh://` context opened a fresh SSH connection, so a plan paid the handshake cost dozens of times.

This introduces reusing one SSH connection per host for a run's lifetime.

At startup dockform drops a `ssh` shim on PATH that injects `ControlMaster` that Docker's ssh helper picks it up transparently. Everything is removed at the end of the run.

Default on for `ssh://` contexts. Disable with `--ssh-multiplex=false` or `DOCKFORM_SSH_MULTIPLEX=false`.